### PR TITLE
[SDPA-960] Added check for null values.

### DIFF
--- a/config/install/core.entity_form_display.taxonomy_term.sites.default.yml
+++ b/config/install/core.entity_form_display.taxonomy_term.sites.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - image.style.thumbnail
     - taxonomy.vocabulary.sites
   module:
+    - tide_core
     - image
     - maxlength
     - text

--- a/tide_site.info.yml
+++ b/tide_site.info.yml
@@ -32,6 +32,3 @@ config_devel:
     - field.storage.taxonomy_term.field_site_footer_menu
     - field.storage.taxonomy_term.field_acknowledgement_to_country.yml
     - field.storage.media.field_media_site
-    - field.storage.node.field_node_site
-    - field.storage.node.field_node_primary_site
-    - taxonomy.vocabulary.sites

--- a/tide_site.module
+++ b/tide_site.module
@@ -634,15 +634,17 @@ function tide_site_search_api_index_items_alter(\Drupal\search_api\IndexInterfac
     /** @var \Drupal\tide_site\AliasStorage $alias_storage */
     $alias_storage = \Drupal::service('tide_site.alias_storage');
 
-    $nid = $item->getField("nid")->getValues()[0];
-    $node = \Drupal\node\Entity\Node::load($nid);
-    $path = $alias_storage->load(['source' => "/node/" . $nid]);
+    if (!is_null($item->getField("nid"))) {
+      $nid = $item->getField("nid")->getValues()[0];
+      $node = \Drupal\node\Entity\Node::load($nid);
+      $path = $alias_storage->load(['source' => "/node/" . $nid]);
       if ($path) {
-        $aliases = $alias_helper->getAllSiteAliases($path, $node);
-      }
+          $aliases = $alias_helper->getAllSiteAliases($path, $node);
+        }
       if ($aliases){
         $url->setValues($aliases);
         $item->setField("url", $url);
       }
+    }
   }
 }


### PR DESCRIPTION
JIRA: https://digital-engagement.atlassian.net/browse/SDPA-960

PR in content-vic-gov-au: https://github.com/dpc-sdp/content-vic-gov-au/pull/285

This PR fixed the following error messages during the `composer:app db-import` step:

```php
error: Call to a member function getValues() on null in /app/docroot/modules/contrib/tide_site/tide_site.module on line 637 #0 /app/docroot/core/lib/Drupal/Core/Extension/ModuleHandler.php(539): tide_site_search_api_index_items_alter(Object(Drupal\search_api\Entity\Index), Array, NULL)
#1 /app/docroot/modules/contrib/search_api/src/Entity/Index.php(963): Drupal\Core\Extension\ModuleHandler->alter('search_api_inde...', Object(Drupal\search_api\Entity\Index), Array)
#2 /app/docroot/modules/contrib/search_api/src/Utility/PostRequestIndexing.php(71): Drupal\search_api\Entity\Index->indexSpecificItems(Array)
#3 /app/docroot/core/lib/Drupal/Core/EventSubscriber/KernelDestructionSubscriber.php(51): Drupal\search_api\Utility\PostRequestIndexing->destruct()
#4 [internal function]: Drupal\Core\EventSubscriber\KernelDestructionSubscriber->onKernelTerminate(Object(Symfony\Component\HttpKernel\Event\PostResponseEvent), 'kernel.terminat...', Object(Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher))
#5 /app/docroot/core/lib/Drupal/Component/EventDispatcher/ContainerAwareEventDispatcher.php(111): call_user_func(Array, Object(Symfony\Component\HttpKernel\Event\PostResponseEvent), 'kernel.terminat...', Object(Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher))
#6 /app/vendor/symfony/http-kernel/HttpKernel.php(88): Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher->dispatch('kernel.terminat...', Object(Symfony\Component\HttpKernel\Event\PostResponseEvent))
#7 /app/vendor/stack/builder/src/Stack/StackedHttpKernel.php(32): Symfony\Component\HttpKernel\HttpKernel->terminate(Object(Symfony\Component\HttpFoundation\Request), Object(Symfony\Component\HttpFoundation\Response))
#8 /app/docroot/core/lib/Drupal/Core/DrupalKernel.php(644): Stack\StackedHttpKernel->terminate(Object(Symfony\Component\HttpFoundation\Request), Object(Symfony\Component\HttpFoundation\Response))
#9 /app/vendor/drush/drush/lib/Drush/Boot/DrupalBoot8.php(202): Drupal\Core\DrupalKernel->terminate(Object(Symfony\Component\HttpFoundation\Request), Object(Symfony\Component\HttpFoundation\Response))
#10 /app/vendor/drush/drush/includes/preflight.inc(75): Drush\Boot\DrupalBoot8->terminate()
#11 /app/vendor/drush/drush/drush.php(12): drush_main()
#12 {main}
Error: Call to a member function getValues() on null in tide_site_search_api_index_items_alter() (line 637 of /app/docroot/modules/contrib/tide_site/tide_site.module).
Drush command terminated abnormally due to an unrecoverable error.       [error]
```