### PR TITLE
[SDPA-3154] Added an update hook

### DIFF
--- a/tide_site.install
+++ b/tide_site.install
@@ -149,3 +149,13 @@ function tide_site_update_8005() {
     }
   }
 }
+
+/**
+ * Updating summary_contents view.
+ */
+function tide_site_update_8006() {
+  $config_path = drupal_get_path('module', 'tide_site') . '/config/install';
+  $source = new FileStorage($config_path);
+  $config_storage = \Drupal::service('config.storage');
+  $config_storage->write('views.view.summary_contents', $source->read('views.view.summary_contents'));
+}


### PR DESCRIPTION
SDPA-3154 Added an update hook for updating views.view.summary_contents

In the [last PR](https://github.com/dpc-sdp/tide_site/pull/32), we should add an update hook, but we didn't.

This PR is for fixing the issue described above.