### PR TITLE
SDPA-3786 makes site field to be required.

### DIFF
--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
-export GH_COMMIT=a06d079ad232a38cf4cc39feaa4dd8f1df3fe9e2
+# export GH_COMMIT=COMMIT_SHA
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"

--- a/tide_site.install
+++ b/tide_site.install
@@ -6,6 +6,8 @@
  */
 
 use Drupal\Core\Config\FileStorage;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\field\Entity\FieldConfig;
 
 /**
  * Implements hook_install().
@@ -183,5 +185,19 @@ function tide_site_update_8006() {
     }
 
     $entity_form_display->save();
+  }
+}
+
+/**
+ * Change field_media_site to be required.
+ */
+function tide_site_update_8007() {
+  $entity_type = 'media';
+  $field_name = 'field_media_site';
+  $field_storage = FieldStorageConfig::loadByName($entity_type, $field_name);
+  foreach ($field_storage->getBundles() as $bundle) {
+    $field = FieldConfig::loadByName($entity_type, $bundle, $field_name);
+    $field->set('required', TRUE);
+    $field->save();
   }
 }


### PR DESCRIPTION
## JIRA
https://digital-engagement.atlassian.net/browse/SDPA-3786

## Changes
1. adds an update hook `tide_media_update_8010`
2. updates tide_media compatible with tide_core 1.5.4
3. change `GH_COMMIT` to `GH_COMMIT=COMMIT_SHA` in the dev-tools.sh file

## Screenshot
![image](https://user-images.githubusercontent.com/8788145/74396535-68cb3500-4e66-11ea-84be-73961623897a.png)

https://github.com/dpc-sdp/content-vic-gov-au/pull/796
https://github.com/dpc-sdp/tide_media/pull/34