### PR TITLE
Enabled alt field for site logo.

### DIFF
--- a/config/install/field.field.taxonomy_term.sites.field_site_logo.yml
+++ b/config/install/field.field.taxonomy_term.sites.field_site_logo.yml
@@ -22,7 +22,7 @@ settings:
   max_filesize: ''
   max_resolution: ''
   min_resolution: ''
-  alt_field: false
+  alt_field: true
   alt_field_required: false
   title_field: false
   title_field_required: false

--- a/tests/behat/features/fields.media.feature
+++ b/tests/behat/features/fields.media.feature
@@ -64,5 +64,3 @@ Feature: Site fields on media
     And I should see an "fieldset#edit-field-media-site--wrapper.required" element
     When I go to "media/add/image"
     And I should see an "fieldset#edit-field-media-site--wrapper.required" element
-    When I go to "media/add/video"
-    And I should see an "fieldset#edit-field-media-site--wrapper.required" element

--- a/tide_site.install
+++ b/tide_site.install
@@ -239,3 +239,16 @@ function tide_site_update_8010() {
   $config_storage = \Drupal::service('config.storage');
   $config_storage->write($view, $source->read($view));
 }
+
+/**
+ * Enable alt field for site logo.
+ */
+function tide_site_update_8011() {
+  $entity_type = 'taxonomy_term';
+  $bundle = 'sites';
+  $field_name = 'field_site_logo';
+  $field = FieldConfig::loadByName($entity_type, $bundle, $field_name);
+  if ($field) {
+    $field->setSetting('alt_field', TRUE)->save();
+  }
+}


### PR DESCRIPTION
This PR is to enable the `alt` field for Site logo as per request from WorkSafe.

On-behalf-of: @salsadigitalauorg <sonny@salsadigital.com.au>