### PR TITLE
Fixed fatal errors in update hooks.

### DIFF
--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
-# export GH_COMMIT=COMMIT_SHA
+export GH_COMMIT='945b524b255be66644977d80fef3528871f38241'
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"

--- a/tide_site.install
+++ b/tide_site.install
@@ -196,10 +196,14 @@ function tide_site_update_8007() {
   $entity_type = 'media';
   $field_name = 'field_media_site';
   $field_storage = FieldStorageConfig::loadByName($entity_type, $field_name);
-  foreach ($field_storage->getBundles() as $bundle) {
-    $field = FieldConfig::loadByName($entity_type, $bundle, $field_name);
-    $field->set('required', TRUE);
-    $field->save();
+  if ($field_storage) {
+    foreach ($field_storage->getBundles() as $bundle) {
+      $field = FieldConfig::loadByName($entity_type, $bundle, $field_name);
+      if ($field) {
+        $field->set('required', TRUE);
+        $field->save();
+      }
+    }
   }
 }
 
@@ -207,27 +211,29 @@ function tide_site_update_8007() {
  * Disable default content view.
  */
 function tide_site_update_8008() {
-  $view = 'content';
-  \Drupal::entityTypeManager()->getStorage('view')
-    ->load($view)
-    ->setStatus(FALSE)
-    ->save();
+  $view_id = 'content';
+  $view = \Drupal::entityTypeManager()->getStorage('view')->load($view_id);
+  if ($view) {
+    $view->setStatus(FALSE)->save();
+  }
 }
 
 /**
  * Disable summary_contents view.
  */
 function tide_site_update_8009() {
-  $view = 'summary_contents';
-  \Drupal::entityTypeManager()->getStorage('view')
-    ->load($view)
-    ->setStatus(FALSE)
-    ->save();
+  $view_id = 'summary_contents';
+  $view = \Drupal::entityTypeManager()->getStorage('view')->load($view_id);
+  if ($view) {
+    $view->setStatus(FALSE)->save();
 
-  \Drupal::entityTypeManager()->getStorage('view')
-    ->load($view)->delete();
-  \Drupal::configFactory()->getEditable('views.view.summary_contents')->delete();
-
+    $view->delete();
+    $config = \Drupal::configFactory()
+      ->getEditable('views.view.summary_contents');
+    if ($config) {
+      $config->delete();
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Fix fatal errors when running update.
```
Error: Call to a member function setStatus() on null in tide_site_update_8009() (line 224 of /app/docroot/modules/contrib/tide_site/tide_site.install)
```
On-behalf-of: @salsadigitalauorg <sonny@salsadigital.com.au>