### PR TITLE
Enable svg site logo

### DIFF
--- a/config/install/field.field.taxonomy_term.sites.field_site_logo.yml
+++ b/config/install/field.field.taxonomy_term.sites.field_site_logo.yml
@@ -18,7 +18,7 @@ default_value: {  }
 default_value_callback: ''
 settings:
   file_directory: site_logo
-  file_extensions: 'png gif jpg jpeg svg'
+  file_extensions: 'png gif jpg jpeg'
   max_filesize: ''
   max_resolution: ''
   min_resolution: ''

--- a/config/install/field.field.taxonomy_term.sites.field_site_logo.yml
+++ b/config/install/field.field.taxonomy_term.sites.field_site_logo.yml
@@ -18,7 +18,7 @@ default_value: {  }
 default_value_callback: ''
 settings:
   file_directory: site_logo
-  file_extensions: 'png gif jpg jpeg'
+  file_extensions: 'png gif jpg jpeg svg'
   max_filesize: ''
   max_resolution: ''
   min_resolution: ''

--- a/tide_site.install
+++ b/tide_site.install
@@ -322,3 +322,16 @@ function tide_site_update_8016() {
   $config_storage = \Drupal::service('config.storage');
   $config_storage->write($view, $source->read($view));
 }
+
+
+/**
+ * Enable SVG filetype for site logo.
+ */
+function tide_site_update_8017() {
+  $view = 'field.field.taxonomy_term.sites.field_site_logo';
+  $config_path = drupal_get_path('module', 'tide_site') . '/config/install';
+  $source = new FileStorage($config_path);
+  $config_storage = \Drupal::service('config.storage');
+  $config_storage->write($view, $source->read($view));
+}
+

--- a/tide_site.install
+++ b/tide_site.install
@@ -323,7 +323,6 @@ function tide_site_update_8016() {
   $config_storage->write($view, $source->read($view));
 }
 
-
 /**
  * Enable SVG filetype for site logo.
  */
@@ -334,4 +333,3 @@ function tide_site_update_8017() {
   $config_storage = \Drupal::service('config.storage');
   $config_storage->write($view, $source->read($view));
 }
-

--- a/tide_site.install
+++ b/tide_site.install
@@ -327,9 +327,11 @@ function tide_site_update_8016() {
  * Enable SVG filetype for site logo.
  */
 function tide_site_update_8017() {
-  $view = 'field.field.taxonomy_term.sites.field_site_logo';
-  $config_path = drupal_get_path('module', 'tide_site') . '/config/install';
-  $source = new FileStorage($config_path);
-  $config_storage = \Drupal::service('config.storage');
-  $config_storage->write($view, $source->read($view));
+  $entity_type = 'taxonomy_term';
+  $bundle = 'sites';
+  $field_name = 'field_site_logo';
+  $field = FieldConfig::loadByName($entity_type, $bundle, $field_name);
+  if ($field) {
+    $field->setSetting('file_extensions', 'png gif jpg jpeg svg')->save();
+  }
 }


### PR DESCRIPTION
This feature will enable svg as allowed filetype for sites_logo taxonomy. It looks like some of the fields already allow svg filetype and this field doesnt.

JIRA Ticket: https://digital-engagement.atlassian.net/browse/TVD-65