### PR TITLE
Removed checking if the alias does exists on node update.

### DIFF
--- a/src/AliasStorageHelper.php
+++ b/src/AliasStorageHelper.php
@@ -257,14 +257,13 @@ class AliasStorageHelper {
         /** @var \Drupal\Core\Entity\EntityStorageInterface $path_storage */
         $path_storage = $this->entityTypeManager->getStorage('path_alias');
         try {
-          if (!$this->isAliasExists($alias, $path->language()->getId())) {
-            if ($is_new) {
-              $path_storage->create([
-                'path' => $path->getPath(),
-                'alias' => $alias,
-                'langcode' => $path->language()->getId(),
-              ])->save();
-            }
+          if ($is_new) {
+            $this->uniquify($alias, $path->language()->getId());
+            $path_storage->create([
+              'path' => $path->getPath(),
+              'alias' => $alias,
+              'langcode' => $path->language()->getId(),
+            ])->save();
           }
         }
         catch (\Exception $exception) {


### PR DESCRIPTION
Issue:
- Create a landing page "Standup Session" and save it as published
- Create event "Standup Session" and save it as draft. A new alias will be generated.
- Change moderation state from draft to published and click save. Alias will be removed and changed to node/123

The flow of condition is:
- This hook "tide_site_node_update" is trigerred on node_update
- Do a check if the alias doesnt exists. If it doesn't then create a new unique alias i.e. site-391/event-blah
- Do a check if the alias exists. Our code would not create a new alias i.e. site-391/event-blah but instead below will happen:
  - Drupal pathauto will get trigerred and it will create a new alias i.e. /event-blah
  - This hook "tide_site_path_alias_update" will get called and it will remove the new alias built by drupal i.e. /event-blah because it doesn't contains site prefix and due to that we will have a path of node/123 instead of an alias.