### PR TITLE
[SDPA-4591] adds tide_site custom path processor

### DIFF
--- a/src/PathProcessor/TideSitePathProcessor.php
+++ b/src/PathProcessor/TideSitePathProcessor.php
@@ -4,7 +4,6 @@ namespace Drupal\tide_site\PathProcessor;
 
 use Drupal\node\Entity\Node;
 use Drupal\path_alias\AliasManagerInterface;
-use Drupal\Core\PathProcessor\InboundPathProcessorInterface;
 use Drupal\Core\PathProcessor\OutboundPathProcessorInterface;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\tide_site\AliasStorageHelper;
@@ -15,7 +14,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Path processor for tide_site module.
  */
-class TideSitePathProcessor implements InboundPathProcessorInterface, OutboundPathProcessorInterface {
+class TideSitePathProcessor implements OutboundPathProcessorInterface {
   use ContainerAwareTrait;
 
   /**
@@ -37,7 +36,7 @@ class TideSitePathProcessor implements InboundPathProcessorInterface, OutboundPa
    *
    * @var \Drupal\tide_site\AliasStorageHelper
    */
-  protected $tidAliasHelper;
+  protected $tideAliasHelper;
 
   /**
    * Constructs a PathProcessorAlias object.
@@ -53,14 +52,6 @@ class TideSitePathProcessor implements InboundPathProcessorInterface, OutboundPa
     $this->aliasManager = $alias_manager;
     $this->tideSiteHelper = $siteHelper;
     $this->tideAliasHelper = $aliasStorageHelper;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function processInbound($path, Request $request) {
-    $path = $this->aliasManager->getPathByAlias($path);
-    return $path;
   }
 
   /**

--- a/src/PathProcessor/TideSitePathProcessor.php
+++ b/src/PathProcessor/TideSitePathProcessor.php
@@ -52,7 +52,7 @@ class TideSitePathProcessor implements InboundPathProcessorInterface, OutboundPa
   public function __construct(AliasManagerInterface $alias_manager, TideSiteHelper $siteHelper, AliasStorageHelper $aliasStorageHelper) {
     $this->aliasManager = $alias_manager;
     $this->tideSiteHelper = $siteHelper;
-    $this->tidAliasHelper = $aliasStorageHelper;
+    $this->tideAliasHelper = $aliasStorageHelper;
   }
 
   /**
@@ -76,7 +76,7 @@ class TideSitePathProcessor implements InboundPathProcessorInterface, OutboundPa
         if (preg_match("/\/(\d+)$/", $path, $matches)) {
           $nid = $matches[1];
           $node = Node::load($nid);
-          $aliases = $this->tidAliasHelper->loadAll(['path' => $path]);
+          $aliases = $this->tideAliasHelper->loadAll(['path' => $path]);
           // Gets PrimarySite term entity.
           $site = $this->tideSiteHelper->getEntityPrimarySite($node);
           $path = $this->aliasManager->getAliasByPath($path, $langcode);

--- a/src/PathProcessor/TideSitePathProcessor.php
+++ b/src/PathProcessor/TideSitePathProcessor.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\tide_site\PathProcessor;
+
+use Drupal\node\Entity\Node;
+use Drupal\path_alias\AliasManagerInterface;
+use Drupal\Core\PathProcessor\InboundPathProcessorInterface;
+use Drupal\Core\PathProcessor\OutboundPathProcessorInterface;
+use Drupal\Core\Render\BubbleableMetadata;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Path processor for tide_site module.
+ */
+class TideSitePathProcessor implements InboundPathProcessorInterface, OutboundPathProcessorInterface {
+
+  /**
+   * An alias manager for looking up the system path.
+   *
+   * @var \Drupal\path_alias\AliasManagerInterface
+   */
+  protected $aliasManager;
+
+  /**
+   * Constructs a PathProcessorAlias object.
+   *
+   * @param \Drupal\path_alias\AliasManagerInterface $alias_manager
+   *   An alias manager for looking up the system path.
+   */
+  public function __construct(AliasManagerInterface $alias_manager) {
+    $this->aliasManager = $alias_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processInbound($path, Request $request) {
+    $path = $this->aliasManager->getPathByAlias($path);
+    return $path;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processOutbound($path, &$options = [], Request $request = NULL, BubbleableMetadata $bubbleable_metadata = NULL) {
+    if (empty($options['alias'])) {
+      $langcode = isset($options['language']) ? $options['language']->getId() : NULL;
+      $pattern = "\/node\/[0-9]*";
+      if (preg_match('/^' . $pattern . '$/', $path)) {
+        if (preg_match("/\/(\d+)$/", $path, $matches)) {
+          $nid = $matches[1];
+          $node = Node::load($nid);
+          /** @var \Drupal\tide_site\TideSiteHelper $helper */
+          $helper = \Drupal::service('tide_site.helper');
+          /** @var \Drupal\tide_site\AliasStorageHelper $alias_helper */
+          $alias_helper = \Drupal::service('tide_site.alias_storage_helper');
+          $site = $helper->getEntityPrimarySite($node);
+          $path = $this->aliasManager->getAliasByPath($path, $langcode);
+          if (!preg_match('/^' . $pattern . '$/', $path)) {
+            if ($site) {
+              $path_without_site = $alias_helper->getPathAliasWithoutSitePrefix(['alias' => $path]);
+              $path = '/site-' . $site->id() . $path_without_site;
+            }
+          }
+        }
+      }
+      else {
+        $path = $this->aliasManager->getAliasByPath($path, $langcode);
+      }
+      if (strpos($path, '//') === 0) {
+        $path = '/' . ltrim($path, '/');
+      }
+    }
+    return $path;
+  }
+
+}

--- a/src/PathProcessor/TideSitePathProcessor.php
+++ b/src/PathProcessor/TideSitePathProcessor.php
@@ -67,14 +67,16 @@ class TideSitePathProcessor implements OutboundPathProcessorInterface {
         if (preg_match("/\/(\d+)$/", $path, $matches)) {
           $nid = $matches[1];
           $node = Node::load($nid);
-          $aliases = $this->tideAliasHelper->loadAll(['path' => $path]);
-          // Gets PrimarySite term entity.
-          $site = $this->tideSiteHelper->getEntityPrimarySite($node);
-          $path = $this->aliasManager->getAliasByPath($path, $langcode);
-          if ($site && $aliases) {
-            foreach ($aliases as $pathAlias) {
-              if (strpos($pathAlias->getAlias(), '/site-' . $site->id() . '/') !== FALSE) {
-                $path = $pathAlias->getAlias();
+          if ($node !== NULL) {
+            $aliases = $this->tideAliasHelper->loadAll(['path' => $path]);
+            // Gets PrimarySite term entity.
+            $site = $this->tideSiteHelper->getEntityPrimarySite($node);
+            $path = $this->aliasManager->getAliasByPath($path, $langcode);
+            if ($site && $aliases) {
+              foreach ($aliases as $pathAlias) {
+                if (strpos($pathAlias->getAlias(), '/site-' . $site->id() . '/') !== FALSE) {
+                  $path = $pathAlias->getAlias();
+                }
               }
             }
           }

--- a/src/TideSiteServiceProvider.php
+++ b/src/TideSiteServiceProvider.php
@@ -24,6 +24,12 @@ class TideSiteServiceProvider extends ServiceProviderBase {
         ->addArgument(new Reference('tide_site.alias_storage_helper'));
     }
 
+    // Overrides path_alias.path_processor class.
+    if ($container->hasDefinition('path_alias.path_processor')) {
+      $alias_manager_definition = $container->getDefinition('path_alias.path_processor');
+      $alias_manager_definition->setClass('Drupal\tide_site\PathProcessor\TideSitePathProcessor');
+    }
+
     // Overrides linkit.suggestion_manager service (Linkit 5.x).
     if ($container->hasDefinition('linkit.suggestion_manager')) {
       $linkit_definition = $container->getDefinition('linkit.suggestion_manager');

--- a/src/TideSiteServiceProvider.php
+++ b/src/TideSiteServiceProvider.php
@@ -24,12 +24,6 @@ class TideSiteServiceProvider extends ServiceProviderBase {
         ->addArgument(new Reference('tide_site.alias_storage_helper'));
     }
 
-    // Overrides path_alias.path_processor class.
-    if ($container->hasDefinition('path_alias.path_processor')) {
-      $alias_manager_definition = $container->getDefinition('path_alias.path_processor');
-      $alias_manager_definition->setClass('Drupal\tide_site\PathProcessor\TideSitePathProcessor');
-    }
-
     // Overrides linkit.suggestion_manager service (Linkit 5.x).
     if ($container->hasDefinition('linkit.suggestion_manager')) {
       $linkit_definition = $container->getDefinition('linkit.suggestion_manager');

--- a/tide_site.services.yml
+++ b/tide_site.services.yml
@@ -20,4 +20,6 @@ services:
     tags:
       - { name: path_processor_inbound, priority: 300 }
       - { name: path_processor_outbound, priority: 300 }
-    arguments: ['@path_alias.manager']
+    arguments: [ '@path_alias.manager', '@tide_site.helper', '@tide_site.alias_storage_helper' ]
+    calls:
+      - [ setContainer, [ '@service_container' ] ]

--- a/tide_site.services.yml
+++ b/tide_site.services.yml
@@ -18,7 +18,6 @@ services:
   tide_site.path_processor:
     class: Drupal\tide_site\PathProcessor\TideSitePathProcessor
     tags:
-      - { name: path_processor_inbound, priority: 300 }
       - { name: path_processor_outbound, priority: 300 }
     arguments: [ '@path_alias.manager', '@tide_site.helper', '@tide_site.alias_storage_helper' ]
     calls:

--- a/tide_site.services.yml
+++ b/tide_site.services.yml
@@ -15,3 +15,9 @@ services:
     arguments: ['@entity_type.manager', '@entity.repository']
     calls:
       - [setContainer, ['@service_container']]
+  tide_site.path_processor:
+    class: Drupal\tide_site\PathProcessor\TideSitePathProcessor
+    tags:
+      - { name: path_processor_inbound, priority: 300 }
+      - { name: path_processor_outbound, priority: 300 }
+    arguments: ['@path_alias.manager']


### PR DESCRIPTION
### JIRA
https://digital-engagement.atlassian.net/browse/SDPA-4591

### Issue
This is a common issue when using multiple urls. by default, you hit the one of urls that attached to a node, it will take you to the last revision of the path. 
eg. node/123 has `/site-1/hello-world`  and `/site-2/hello-world` path aliases.
you hit `/site-1/hello-world` in the browser, it will redirect you to `/site-2/hello-world` as the later is newest one.

### Changes
This is a custom function that redirects the node url to primary site based path alias.