### PR TITLE
[SDPSUP-2009] fixes redirect uri issue.

### DIFF
--- a/src/AliasStorageHelper.php
+++ b/src/AliasStorageHelper.php
@@ -379,4 +379,18 @@ class AliasStorageHelper {
     }
   }
 
+  /**
+   * Check if the alias eligible to update.
+   */
+  public function eligibleToUpdate(NodeInterface $node, PathAliasInterface $pathAlias) {
+    $path_alias_without_prefix = $this->getPathAliasWithoutSitePrefix(['alias' => $pathAlias->getAlias()]);
+    $original_title = $node->original->getTitle();
+    $cleaned_uri = '/' . \Drupal::service('pathauto.alias_cleaner')
+      ->cleanString($original_title);
+    if ($cleaned_uri == $path_alias_without_prefix) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
 }

--- a/src/TideSiteEntityOperations.php
+++ b/src/TideSiteEntityOperations.php
@@ -113,7 +113,7 @@ class TideSiteEntityOperations implements ContainerInjectionInterface {
         $path = $existing_path_alias->getAlias();
         $site_id = $this->tideSiteHelper->getSiteIdFromSitePrefix($path);
         // If site id cannot be found, just skip it.
-        if (!$site_id) {
+        if (!$site_id || !$this->tideSiteAliasStorageHelper->eligibleToUpdate($node, $existing_path_alias)) {
           continue;
         }
         $changed_alias = '/site-' . $site_id . '/' . $new_uri_without_site_prefix;

--- a/src/TideSiteEntityOperations.php
+++ b/src/TideSiteEntityOperations.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Drupal\tide_site;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\node\NodeInterface;
+use Drupal\path_alias\Entity\PathAlias;
+use Drupal\path_alias\PathAliasInterface;
+use Drupal\pathauto\AliasCleaner;
+use Drupal\pathauto\pathautoGenerator;
+use Drupal\taxonomy\TermInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Defines a class for reacting to entity events.
+ */
+class TideSiteEntityOperations implements ContainerInjectionInterface {
+
+  /**
+   * AliasStorageHelper service.
+   *
+   * @var \Drupal\tide_site\AliasStorageHelper
+   */
+  protected $tideSiteAliasStorageHelper;
+
+  /**
+   * TideSiteHelper service.
+   *
+   * @var \Drupal\tide_site\TideSiteHelper
+   */
+  protected $tideSiteHelper;
+
+  /**
+   * Path storage service.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface|mixed|object
+   */
+  protected $pathStorage;
+
+  /**
+   * PathautoGenerator service.
+   *
+   * @var \Drupal\pathauto\PathautoGenerator
+   */
+  protected $pathautoGenerator;
+
+  /**
+   * AliasCleaner service.
+   *
+   * @var \Drupal\pathauto\AliasCleaner
+   */
+  protected $pathautoAliasCleaner;
+
+  /**
+   * Constructs a new TideSiteEntityOperations object.
+   *
+   * @param \Drupal\tide_site\AliasStorageHelper $aliasStorageHelper
+   *   AliasStorageHelper service.
+   * @param \Drupal\tide_site\TideSiteHelper $siteHelper
+   *   TideSiteHelper service.
+   * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
+   *   EntityTypeManager service.
+   * @param \Drupal\pathauto\PathautoGenerator $generator
+   *   PathautoGenerator service.
+   * @param \Drupal\pathauto\AliasCleaner $aliasCleaner
+   *   AliasCleaner service.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function __construct(AliasStorageHelper $aliasStorageHelper, TideSiteHelper $siteHelper, EntityTypeManager $entityTypeManager, PathautoGenerator $generator, AliasCleaner $aliasCleaner) {
+    $this->tideSiteAliasStorageHelper = $aliasStorageHelper;
+    $this->tideSiteHelper = $siteHelper;
+    $this->pathStorage = $entityTypeManager->getStorage('path_alias');
+    $this->pathautoGenerator = $generator;
+    $this->pathautoAliasCleaner = $aliasCleaner;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('tide_site.alias_storage_helper'),
+      $container->get('tide_site.helper'),
+      $container->get('entity_type.manager'),
+      $container->get('pathauto.generator'),
+      $container->get('pathauto.alias_cleaner')
+    );
+  }
+
+  /**
+   * Acts on a node updating.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node being updated.
+   *
+   * @see \hook_ENTITY_TYPE_update()
+   */
+  public function nodeUpdate(NodeInterface $node) {
+    // If the node has no aliases, we should create them.
+    if (!$this->tideSiteAliasStorageHelper->loadAll(['path' => '/node/' . $node->id()])) {
+      $this->pathautoGenerator->createEntityAlias($node, 'update');
+    }
+    // Get last node revision for comparison purpose.
+    $original_node = $node->original;
+    // If node title changed, we should change the aliases accordingly.
+    if ($node->getTitle() !== $original_node->getTitle()) {
+      $new_uri_without_site_prefix = $this->pathautoAliasCleaner->cleanString($node->getTitle());
+      $existing_path_aliases = $this->tideSiteAliasStorageHelper->loadAll(['path' => '/node/' . $node->id()]);
+      foreach ($existing_path_aliases as $existing_path_alias) {
+        $path = $existing_path_alias->getAlias();
+        $site_id = $this->tideSiteHelper->getSiteIdFromSitePrefix($path);
+        // If site id cannot be found, just skip it.
+        if (!$site_id) {
+          continue;
+        }
+        $changed_alias = '/site-' . $site_id . '/' . $new_uri_without_site_prefix;
+        $this->tideSiteAliasStorageHelper->uniquify($changed_alias, $existing_path_alias->language()
+          ->getId());
+        $existing_path_alias->setAlias($changed_alias)->save();
+      }
+    }
+    $this->tideSiteAliasStorageHelper->deleteOrCreateFromSites($original_node, $node);
+  }
+
+  /**
+   * Acts on a path alias entity being inserted.
+   *
+   * @param \Drupal\path_alias\Entity\PathAliasInterface $pathAlias
+   *   The path alias being inserted.
+   *
+   * @see \hook_ENTITY_TYPE_insert()
+   */
+  public function pathAliasInsert(PathAliasInterface $pathAlias) {
+    $node = $this->tideSiteAliasStorageHelper->getNodeFromPathEntity($pathAlias);
+    if ($node && !$this->tideSiteAliasStorageHelper->isPathHasSitePrefix($pathAlias)) {
+      $this->tideSiteAliasStorageHelper->createSiteAliases($pathAlias, $node);
+      if ($this->tideSiteHelper->getEntitySites($node)) {
+        if (!$this->tideSiteAliasStorageHelper->isPathHasSitePrefix($pathAlias)) {
+          $pathAlias->delete();
+        }
+      }
+    }
+  }
+
+  /**
+   * Acts on a path alias entity being updated.
+   *
+   * @param \Drupal\path_alias\Entity\PathAliasInterface $pathAlias
+   *   The path alias being updated.
+   *
+   * @see \hook_ENTITY_TYPE_update()
+   */
+  public function pathAliasUpdate(PathAliasInterface $pathAlias) {
+    $node = $this->tideSiteAliasStorageHelper->getNodeFromPathEntity($pathAlias);
+    if ($node && !$this->tideSiteAliasStorageHelper->isPathHasSitePrefix($pathAlias)) {
+      $this->tideSiteAliasStorageHelper->updateSiteAliases($pathAlias, $pathAlias->original);
+      if ($this->tideSiteHelper->getEntitySites($node)) {
+        // Delete the current path if it does not have site prefix.
+        if (!$this->tideSiteAliasStorageHelper->isPathHasSitePrefix($pathAlias)) {
+          $pathAlias->delete();
+        }
+      }
+    }
+  }
+
+  /**
+   * Acts on a path alias entity being deleted.
+   *
+   * @param \Drupal\taxonomy\TermInterface $term
+   *   The entity being deleted.
+   *
+   * @see \hook_ENTITY_TYPE_delete()
+   */
+  public function termDelete(TermInterface $term) {
+    // Delete all site aliases of content belong to this Site term.
+    if ($term->bundle() == 'sites') {
+      $site_prefix = $this->tideSiteHelper->getSitePathPrefix($term);
+      $path_ids = \Drupal::entityQuery('path_alias')
+        ->condition('alias', $site_prefix . '/', 'CONTAINS')
+        ->condition('path', '/taxonomy/term/' . $term->id(), '=')
+        ->execute();
+      $this->pathStorage->delete(PathAlias::loadMultiple($path_ids));
+    }
+  }
+
+}

--- a/tide_site.install
+++ b/tide_site.install
@@ -370,8 +370,8 @@ function tide_site_update_8019(&$sandbox) {
     ->getStorage('redirect')
     ->getQuery()
     ->condition('redirect_redirect__uri', '%internal:/node/%', 'LIKE')
-    ->condition('id', $sandbox['current'], '>')
-    ->sort('id', 'ASC')
+    ->condition('rid', $sandbox['current'], '>')
+    ->sort('rid', 'ASC')
     ->range(0, $batch_size)
     ->execute();
   foreach ($redirect_ids as $redirect_id) {

--- a/tide_site.install
+++ b/tide_site.install
@@ -9,6 +9,7 @@ use Drupal\Core\Config\FileStorage;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\taxonomy\TaxonomyPermissions;
+use Drupal\redirect\Entity\Redirect;
 
 /**
  * Implements hook_install().
@@ -346,4 +347,45 @@ function tide_site_update_8018() {
   if ($field) {
     $field->setSetting('file_extensions', 'png gif jpg jpeg svg')->save();
   }
+}
+
+/**
+ * Changes internal:/node/{id} to entity:node/{id}.
+ */
+function tide_site_update_8019(&$sandbox) {
+  if (!isset($sandbox['total'])) {
+    $count = \Drupal::entityTypeManager()
+      ->getStorage('redirect')
+      ->getQuery()
+      ->condition('redirect_redirect__uri', '%internal:/node/%', 'LIKE')
+      ->count()
+      ->execute();
+    $sandbox['total'] = $count;
+    $sandbox['current'] = 0;
+    $sandbox['processed'] = 0;
+    $sandbox['#finished'] = $count ? 0 : 1;
+  }
+  $batch_size = 10;
+  $redirect_ids = \Drupal::entityTypeManager()
+    ->getStorage('redirect')
+    ->getQuery()
+    ->condition('redirect_redirect__uri', '%internal:/node/%', 'LIKE')
+    ->condition('id', $sandbox['current'], '>')
+    ->sort('id', 'ASC')
+    ->range(0, $batch_size)
+    ->execute();
+  foreach ($redirect_ids as $redirect_id) {
+    $sandbox['current'] = $redirect_id;
+    $redirect = Redirect::load($redirect_id);
+    if ($redirect) {
+      $redirect_values = $redirect->get('redirect_redirect')->get(0)->getValue();
+      $nid = substr($redirect_values['uri'], strrpos($redirect_values['uri'], '/') + 1);
+      $redirect_values['uri'] = 'entity:node/' . $nid;
+      $redirect->redirect_redirect->set(0, $redirect_values);
+      $redirect->save();
+    }
+    $sandbox['processed']++;
+  }
+  $sandbox['#finished'] = $sandbox['total'] ? $sandbox['processed'] / $sandbox['total'] : 1;
+  $sandbox['#finished'] = $sandbox['#finished'] > 1 ? 1 : $sandbox['#finished'];
 }

--- a/tide_site.module
+++ b/tide_site.module
@@ -586,7 +586,7 @@ function tide_site_node_update(NodeInterface $node) {
   $tide_site_helper = \Drupal::service('tide_site.helper');
   $path_storage = \Drupal::entityTypeManager()->getStorage('path_alias');
 
-  // If the node has no aliases, we should creat them.
+  // If the node has no aliases, we should create them.
   if (!$alias_storage_helper->loadAll(['path' => '/node/' . $node->id()])) {
     $path_auto_generator = \Drupal::service('pathauto.generator');
     $path_auto_generator->createEntityAlias($node, 'update');

--- a/tide_site.module
+++ b/tide_site.module
@@ -19,6 +19,7 @@ use Drupal\path_alias\Entity\PathAlias;
 use Drupal\path_alias\PathAliasInterface;
 use Drupal\tide_site\TideSitePathAliasListBuilder;
 use Drupal\node\NodeInterface;
+use Drupal\tide_site\TideSiteEntityOperations;
 
 /**
  * Implements hook_entity_bundle_create().
@@ -414,6 +415,7 @@ function tide_site_form_node_form_alter(&$form, FormStateInterface $form_state) 
       ]);
     if ($aliases) {
       $alias_list = [];
+      /** @var \Drupal\path_alias\Entity\PathAliasInterface $alias */
       foreach ($aliases as $alias) {
         if ($alias->isPublished() == FALSE) {
           continue;
@@ -523,117 +525,36 @@ function _tide_site_delete_all_alias(&$form, FormStateInterface $form_state) {
  * Implements hook_ENTITY_TYPE_insert().
  */
 function tide_site_path_alias_insert(PathAliasInterface $path) {
-  /** @var \Drupal\tide_site\AliasStorageHelper $alias_helper */
-  $alias_helper = \Drupal::service('tide_site.alias_storage_helper');
-  $node = $alias_helper->getNodeFromPathEntity($path);
-  if ($node && !$alias_helper->isPathHasSitePrefix($path)) {
-    $alias_helper->createSiteAliases($path, $node);
-    /** @var \Drupal\tide_site\TideSiteHelper $helper */
-    $helper = \Drupal::service('tide_site.helper');
-    if ($helper->getEntitySites($node)) {
-      if (!$alias_helper->isPathHasSitePrefix($path)) {
-        $path->delete();
-      }
-    }
-  }
+  return \Drupal::service('class_resolver')
+    ->getInstanceFromDefinition(TideSiteEntityOperations::class)
+    ->pathAliasInsert($path);
 }
 
 /**
  * Implements hook_ENTITY_TYPE_update().
  */
 function tide_site_path_alias_update(PathAliasInterface $path) {
-  /** @var \Drupal\tide_site\AliasStorageHelper $alias_helper */
-  $alias_helper = \Drupal::service('tide_site.alias_storage_helper');
-  $node = $alias_helper->getNodeFromPathEntity($path);
-  if ($node && !$alias_helper->isPathHasSitePrefix($path)) {
-    $alias_helper->updateSiteAliases($path, $path->original);
-    /** @var \Drupal\tide_site\TideSiteHelper $helper */
-    $helper = \Drupal::service('tide_site.helper');
-    if ($helper->getEntitySites($node)) {
-      // Delete the current path if it does not have site prefix.
-      if (!$alias_helper->isPathHasSitePrefix($path)) {
-        $path->delete();
-      }
-    }
-  }
+  return \Drupal::service('class_resolver')
+    ->getInstanceFromDefinition(TideSiteEntityOperations::class)
+    ->pathAliasUpdate($path);
 }
 
 /**
  * Implements hook_ENTITY_TYPE_delete().
  */
 function tide_site_taxonomy_term_delete($term) {
-  // Delete all site aliases of content belong to this Site term.
-  /** @var \Drupal\taxonomy\TermInterface $term */
-  if ($term->bundle() == 'sites') {
-    /** @var \Drupal\tide_site\TideSiteHelper $helper */
-    $helper = \Drupal::service('tide_site.helper');
-    $path_storage = \Drupal::entityTypeManager()->getStorage('path_alias');
-    $site_prefix = $helper->getSitePathPrefix($term);
-    $path_ids = \Drupal::entityQuery('path_alias')
-      ->condition('alias', $site_prefix . '/', 'CONTAINS')
-      ->condition('path', '/taxonomy/term/' . $term->id(), '=')
-      ->execute();
-    $path_storage->delete(PathAlias::loadMultiple($path_ids));
-  }
+  return \Drupal::service('class_resolver')
+    ->getInstanceFromDefinition(TideSiteEntityOperations::class)
+    ->termDelete($term);
 }
 
 /**
  * Implements hook_ENTITY_TYPE_update().
  */
 function tide_site_node_update(NodeInterface $node) {
-  // Gets required services.
-  $alias_storage_helper = \Drupal::service('tide_site.alias_storage_helper');
-  $tide_site_helper = \Drupal::service('tide_site.helper');
-  $path_storage = \Drupal::entityTypeManager()->getStorage('path_alias');
-
-  // If the node has no aliases, we should create them.
-  if (!$alias_storage_helper->loadAll(['path' => '/node/' . $node->id()])) {
-    $path_auto_generator = \Drupal::service('pathauto.generator');
-    $path_auto_generator->createEntityAlias($node, 'update');
-  }
-
-  // Get last node revision for comparison purpose.
-  $old_node = $node->original;
-  // If node title changed, we should change the aliases accordingly.
-  if ($node->getTitle() !== $old_node->getTitle()) {
-    $new_uri_without_site_prefix = \Drupal::service('pathauto.alias_cleaner')->cleanString($node->getTitle());
-    $existing_path_aliases = $alias_storage_helper->loadAll(['path' => '/node/' . $node->id()]);
-    foreach ($existing_path_aliases as $existing_path_alias) {
-      $path = $existing_path_alias->getAlias();
-      $site_id = $tide_site_helper->getSiteIdFromSitePrefix($path);
-      // If site id cannot be found, just skip it.
-      if (!$site_id) {
-        continue;
-      }
-      $changed_alias = '/site-' . $site_id . '/' . $new_uri_without_site_prefix;
-      $alias_storage_helper->uniquify($changed_alias, $existing_path_alias->language()
-        ->getId());
-      $existing_path_alias->setAlias($changed_alias)->save();
-    }
-  }
-
-  // Compares sites changing.
-  $old_sites = $tide_site_helper->getEntitySites($old_node, TRUE) ?: ['ids' => []];
-  $new_sites = $tide_site_helper->getEntitySites($node, TRUE) ?: ['ids' => []];
-  $unassigned_sites = array_diff($old_sites['ids'], $new_sites['ids']);
-  if ($unassigned_sites) {
-    foreach ($unassigned_sites as $unassigned_site_id) {
-      $site_prefix = $tide_site_helper->getSitePathPrefix($unassigned_site_id);
-      $path_ids = \Drupal::entityQuery('path_alias')
-        ->condition('alias', $site_prefix . '/', 'CONTAINS')
-        ->condition('path', '/node/' . $node->id(), '=')
-        ->execute();
-      if ($path_ids) {
-        $path_storage->delete(PathAlias::loadMultiple($path_ids));
-      }
-    }
-  }
-  $new_assigned_sites = array_diff($new_sites['ids'], $old_sites['ids']);
-  if ($new_assigned_sites) {
-    /** @var \Drupal\tide_site\AliasStorageHelper $alias_helper */
-    $alias_helper = \Drupal::service('tide_site.alias_storage_helper');
-    $alias_helper->regenerateNodeSiteAliases($node, $new_assigned_sites);
-  }
+  return \Drupal::service('class_resolver')
+    ->getInstanceFromDefinition(TideSiteEntityOperations::class)
+    ->nodeUpdate($node);
 }
 
 /**

--- a/tide_site.module
+++ b/tide_site.module
@@ -18,6 +18,7 @@ use Drupal\views\ViewExecutable;
 use Drupal\path_alias\Entity\PathAlias;
 use Drupal\path_alias\PathAliasInterface;
 use Drupal\tide_site\TideSitePathAliasListBuilder;
+use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_entity_bundle_create().
@@ -414,6 +415,9 @@ function tide_site_form_node_form_alter(&$form, FormStateInterface $form_state) 
     if ($aliases) {
       $alias_list = [];
       foreach ($aliases as $alias) {
+        if ($alias->isPublished() == FALSE) {
+          continue;
+        }
         if (!isset($alias_list[$alias->language()->getId()])) {
           $alias_list[$alias->language()->getId()] = [
             '#theme' => 'item_list',
@@ -576,27 +580,45 @@ function tide_site_taxonomy_term_delete($term) {
 /**
  * Implements hook_ENTITY_TYPE_update().
  */
-function tide_site_node_update($node) {
-  // Regenerate site aliases of the updated node.
-  /** @var \Drupal\tide_site\AliasStorage $alias_storage */
+function tide_site_node_update(NodeInterface $node) {
+  // Gets required services.
   $alias_storage_helper = \Drupal::service('tide_site.alias_storage_helper');
-
+  $tide_site_helper = \Drupal::service('tide_site.helper');
   $path_storage = \Drupal::entityTypeManager()->getStorage('path_alias');
 
-  /** @var \Drupal\node\NodeInterface $node */
+  // If the node has no aliases, we should creat them.
   if (!$alias_storage_helper->loadAll(['path' => '/node/' . $node->id()])) {
-    /** @var \Drupal\pathauto\PathautoGenerator $path_auto_generator */
     $path_auto_generator = \Drupal::service('pathauto.generator');
     $path_auto_generator->createEntityAlias($node, 'update');
   }
+
+  // Get last node revision for comparison purpose.
   $old_node = $node->original;
-  $helper = \Drupal::service('tide_site.helper');
-  $old_sites = $helper->getEntitySites($old_node, TRUE) ?: ['ids' => []];
-  $new_sites = $helper->getEntitySites($node, TRUE) ?: ['ids' => []];
+  // If node title changed, we should change the aliases accordingly.
+  if ($node->getTitle() !== $old_node->getTitle()) {
+    $new_uri_without_site_prefix = \Drupal::service('pathauto.alias_cleaner')->cleanString($node->getTitle());
+    $existing_path_aliases = $alias_storage_helper->loadAll(['path' => '/node/' . $node->id()]);
+    foreach ($existing_path_aliases as $existing_path_alias) {
+      $path = $existing_path_alias->getAlias();
+      $site_id = $tide_site_helper->getSiteIdFromSitePrefix($path);
+      // If site id cannot be found, just skip it.
+      if (!$site_id) {
+        continue;
+      }
+      $changed_alias = '/site-' . $site_id . '/' . $new_uri_without_site_prefix;
+      $alias_storage_helper->uniquify($changed_alias, $existing_path_alias->language()
+        ->getId());
+      $existing_path_alias->setAlias($changed_alias)->save();
+    }
+  }
+
+  // Compares sites changing.
+  $old_sites = $tide_site_helper->getEntitySites($old_node, TRUE) ?: ['ids' => []];
+  $new_sites = $tide_site_helper->getEntitySites($node, TRUE) ?: ['ids' => []];
   $unassigned_sites = array_diff($old_sites['ids'], $new_sites['ids']);
   if ($unassigned_sites) {
     foreach ($unassigned_sites as $unassigned_site_id) {
-      $site_prefix = $helper->getSitePathPrefix($unassigned_site_id);
+      $site_prefix = $tide_site_helper->getSitePathPrefix($unassigned_site_id);
       $path_ids = \Drupal::entityQuery('path_alias')
         ->condition('alias', $site_prefix . '/', 'CONTAINS')
         ->condition('path', '/node/' . $node->id(), '=')

--- a/tide_site.module
+++ b/tide_site.module
@@ -691,3 +691,20 @@ function tide_site_entity_type_alter(array &$entity_types) {
     $entity_types['path_alias']->setListBuilderClass(TideSitePathAliasListBuilder::class);
   }
 }
+
+/**
+ * Implements hook_ENTITY_TYPE_presave().
+ */
+function tide_site_redirect_presave($redirect) {
+  if ($redirect->isNew()) {
+    // By default, redirect entity saved as internal:/node/{id}
+    // but, we want them saved as 'entity:node/{id}'(The entity itself).
+    $pattern = "\internal\:\/node\/[0-9]*";
+    $redirect_values = $redirect->get('redirect_redirect')->get(0)->getValue();
+    if (preg_match('/^' . $pattern . '$/', $redirect_values['uri'])) {
+      $nid = substr($redirect_values['uri'], strrpos($redirect_values['uri'], '/') + 1);
+      $redirect_values['uri'] = 'entity:node/' . $nid;
+      $redirect->redirect_redirect->set(0, $redirect_values);
+    }
+  }
+}


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPSUP-2009

### Issues
This PR is trying to fix 2 issues
   - path alias should change along with node title changing.
   - redirect module saves destination as `internal:/node/{id}`, which is not what we want. we want `entity:node/{id}`

### Changes
1. update `tide_site_node_update` method
2. add `tide_site_redirect_presave` method to change saved value to `entity:node/{id}` for redirect module.
3. add an update hook for correcting redirect table


BTW, Complaining :trollface:, not really related to this PR.
the revision of path alias is not working as designed(I think).
if you change a path alias, there is no revision generated, you cannot track the previous values. so the revision table is meaningless.
I will try to raise a ticket to drupal.org