### PR TITLE
Check that $node is properly populated before continuing

### DIFF
--- a/modules/tide_site_preview/src/Plugin/Block/PreviewLinksBlock.php
+++ b/modules/tide_site_preview/src/Plugin/Block/PreviewLinksBlock.php
@@ -235,6 +235,11 @@ class PreviewLinksBlock extends BlockBase implements ContainerFactoryPluginInter
         $node = NULL;
       }
     }
+
+    if (!($node instanceof NodeInterface)) {
+      $node = NULL;
+    }
+
     $this->currentNode = $node;
 
     return $this->currentNode;


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SW-705

### Changes
1. Some routes that have a 'node' parameter don't necessarily hydrate the parameter, e.g. /node/$nid/revisions/$vid/revert. This change checks that $node is properly populated and sets it to NULL if not.