### PR TITLE
Added condition to check if config sync is running before field creation

### DIFF
--- a/tide_site.module
+++ b/tide_site.module
@@ -26,6 +26,11 @@ use Drupal\tide_site\TideSitePathAliasListBuilder;
  * Implements hook_entity_bundle_create().
  */
 function tide_site_entity_bundle_create($entity_type_id, $bundle) {
+  // Don't do anything else during config sync.
+  if (\Drupal::isConfigSyncing()) {
+    return;
+  }
+
   /** @var \Drupal\tide_site\TideSiteFields $fields_helper */
   $fields_helper = \Drupal::service('tide_site.fields');
 


### PR DESCRIPTION
Added condition to check if config sync is running before we create fields on new content type.

When a new content type is created its done through updatedb process which will trigger entity_bundle_create. Once it is done we can do a config export which will give us two new fields.

If we run the deploy process config import will again try to create the content type and run entity_bundle_create hook which will error out because now the field exists. This will also stop any layout changes for the content type form display as it will try to add two new fields to the form layout display and overwrite any layout changes done by us.