### PR TITLE
[SW-827] Added alter hook for cardLinkEnhancer to handle the url belongs to other sites.

### DIFF
--- a/tide_site.module
+++ b/tide_site.module
@@ -800,3 +800,49 @@ function tide_site_share_link_token_view_alter(array &$build, EntityInterface $t
     }
   }
 }
+
+/**
+ * Implements hook_tide_card_link_enhancer_undo_transform_alter().
+ *
+ * @see Drupal\tide_landing_page\Plugin\jsonapi\FieldEnhancer\CardLinkEnhancer::doUndoTransform()
+ */
+function tide_site_tide_card_link_enhancer_undo_transform_alter(&$data, &$context) {
+  if (empty($data['pid']) || empty($data['url'])) {
+    return;
+  }
+
+  /** @var \Drupal\tide_site\TideSiteHelper $helper */
+  $helper = \Drupal::service('tide_site.helper');
+  /** @var \Drupal\tide_site\AliasStorageHelper $alias_helper */
+  $alias_helper = \Drupal::service('tide_site.alias_storage_helper');
+
+  $data['origin_alias'] = $data['alias'];
+  $data['alias'] = $alias_helper->getPathAliasWithoutSitePrefix($data);
+
+  /** @var \Drupal\path_alias\Entity\PathAlias $path_entity */
+  $path_entity = PathAlias::load($data['pid']);
+  if ($path_entity) {
+    $node = $alias_helper->getNodeFromPathEntity($path_entity);
+    if ($node) {
+      // Get the Site ID parameter.
+      $request = \Drupal::request();
+      $site_id = $request->get('site');
+      if (!$site_id) {
+        return;
+      }
+
+      // The URL from Tide API is already relative.
+      $data['origin_url'] = $data['url'];
+      // Check if the link belongs to the current site.
+      if ($helper->isEntityBelongToSite($node, $site_id)) {
+        $site_url = '';
+      }
+      else {
+        $site_url = $helper->getEntityPrimarySiteBaseUrl($node);
+        $data['url'] = $helper->getNodeUrlFromPrimarySite($node);
+      }
+      // Remove site prefix from the  URL.
+      $data['url'] = $alias_helper->getPathAliasWithoutSitePrefix(['alias' => $data['url']], $site_url);
+    }
+  }
+}


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SW-827

### Issue
For the card consolidation story, a new enhancer is added named cardLinkEnhancer. When an internal link is added to the card link field and the added links belong to another site, the FE throws an error on trying to access that link. There is a alter hook for tide_path_enhancer `tide_site_tide_path_enhancer_undo_transform_alter` that resolves this and the same functionality is need for the cardLinkEnhancer alter hook.

### Changes
1. Added functionality in the cardLinkEnhancer alter hook to handle the link that belongs to other sites.

### Related PRs - 
https://github.com/dpc-sdp/tide_landing_page/pull/131

### Future work
A ticket is created to build a helper function which will be called in both of the alter hook for path enhancer and cardLinkEnhancer as they both are doing the same functionalities. It needs a solution direction and broader test case as the path enhancer is is used widely in all projects. 
Ticket - https://digital-engagement.atlassian.net/browse/SDPA-5062
Testing PR- https://github.com/dpc-sdp/tide_site/pull/83