### PR TITLE
Added settings for simple sitemap.

### DIFF
--- a/modules/tide_site_simple_sitemap/tide_site_simple_sitemap.install
+++ b/modules/tide_site_simple_sitemap/tide_site_simple_sitemap.install
@@ -110,6 +110,7 @@ function tide_site_simple_sitemap_install($is_syncing) {
     'weight' => 0,
   ]);
   $generator->saveSetting('default_variant', 'default');
+  $generator->saveSetting('xsl', FALSE);
   $generator->setVariants('default')->addCustomLink('/', [
     'priority' => '1.0',
     'changefreq' => 'daily',
@@ -288,6 +289,7 @@ function tide_site_simple_sitemap_update_8006() {
     'weight' => 0,
   ]);
   $generator->saveSetting('default_variant', 'default');
+  $generator->saveSetting('xsl', FALSE);
   $generator->setVariants('default')->addCustomLink('/', [
     'priority' => '1.0',
     'changefreq' => 'daily',


### PR DESCRIPTION
### Issue
The XSL option is added in the new update of simple sitemap. By default the XSL value is true and it causes issues on rendering the sitemap in the FE.

### 
Changes
Set the XSL value to false during install and also in update hook for the exisiting projects that using this module.