### PR TITLE
[SW-2075] Clean up memory when a site-based index is done.

### DIFF
--- a/modules/tide_site_simple_sitemap/src/Plugin/simple_sitemap/SitemapGenerator/TideDefaultSitemapGenerator.php
+++ b/modules/tide_site_simple_sitemap/src/Plugin/simple_sitemap/SitemapGenerator/TideDefaultSitemapGenerator.php
@@ -89,6 +89,7 @@ class TideDefaultSitemapGenerator extends DefaultSitemapGenerator {
             $links_per_site[$site_id][] = $site_link;
           }
         }
+        \Drupal::service('entity.memory_cache')->deleteAll();
       }
 
       // Now we have the sitemap of all sites.


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SW-2075

### issues
sitemaps.xml is sometimes broken, and all site-based indexes will be gone.

### Fix
It might be because of a memory issue. sometimes core cronjob break when sitemap.xml indexing runs out of memory, and all sitemaps will be gone.
so, we have prepared 2 ways to prevent the disappearing sitemaps.
1. split sitemaps cronjob from drupalcore cronjobs to its own.
    - https://github.com/dpc-sdp/ansible-role-sdp-tide-platform/pull/28/files
2. clean up the memory cache when the site-based sitemap.xml loop is done.
     - https://github.com/dpc-sdp/tide_site/pull/104/files#diff-3d252e549b49a579815e4aa03acdf1dd4b508a2ef569a05435f397e389d6145dR92

we have tested it for a week, looks fine.
https://nginx-php.pr-1385.content-vic.sdp2.sdp.vic.gov.au/