### PR TITLE
Feature/R20-293 tide site theming

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "require": {
-        "dpc-sdp/tide_core": "dev-feature/SRM-512_update_drupal_to_9.4",
-        "dpc-sdp/tide_media": "dev-feature/SRM-512_update_drupal_to_9.4",
+        "dpc-sdp/tide_core": "^3.1.13",
+        "dpc-sdp/tide_media": "^3.0.8",
         "drupal/create_menus_permission": "^1.0",
         "drupal/key_value_field": "^1.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "require": {
         "dpc-sdp/tide_core": "dev-feature/SRM-512_update_drupal_to_9.4",
         "dpc-sdp/tide_media": "dev-feature/SRM-512_update_drupal_to_9.4",
-        "drupal/create_menus_permission": "^1.0"
+        "drupal/create_menus_permission": "^1.0",
+        "drupal/key_value_field": "^1.3"
     },
     "suggest": {
         "dpc-sdp/tide_api:^3.0.0": "Allows to use Drupal in headless mode"

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "require": {
-        "dpc-sdp/tide_core": "^3.0.0",
-        "dpc-sdp/tide_media": "^3.0.0",
+        "dpc-sdp/tide_core": "dev-feature/SRM-512_update_drupal_to_9.4",
+        "dpc-sdp/tide_media": "dev-feature/SRM-512_update_drupal_to_9.4",
         "drupal/create_menus_permission": "^1.0"
     },
     "suggest": {

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
-# export GH_COMMIT=COMMIT_SHA
+export GH_COMMIT=960eba39ed9543b17654dbd5e06f3a2ab2b1fb4b
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
-export GH_COMMIT=9dbb1773923a6b5ac95583a21cf1b293a593679a
+# export GH_COMMIT=COMMIT_SHA
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
-export GH_COMMIT=960eba39ed9543b17654dbd5e06f3a2ab2b1fb4b
+export GH_COMMIT=9dbb1773923a6b5ac95583a21cf1b293a593679a
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"

--- a/modules/tide_site_theming/config/install/field.field.taxonomy_term.sites.field_site_feature_flags.yml
+++ b/modules/tide_site_theming/config/install/field.field.taxonomy_term.sites.field_site_feature_flags.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_site_feature_flags
+    - taxonomy.vocabulary.sites
+  module:
+    - key_value_field
+id: taxonomy_term.sites.field_site_feature_flags
+field_name: field_site_feature_flags
+entity_type: taxonomy_term
+bundle: sites
+label: 'Feature flags'
+description: 'Site feature flag field allows adding “key” “value” pairs to apply feature flag e.g <code>key => footerTheme, value => neutral</code>'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: key_value

--- a/modules/tide_site_theming/config/install/field.field.taxonomy_term.sites.field_site_theme_values.yml
+++ b/modules/tide_site_theming/config/install/field.field.taxonomy_term.sites.field_site_theme_values.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_site_theme_values
+    - taxonomy.vocabulary.sites
+  module:
+    - key_value_field
+id: taxonomy_term.sites.field_site_theme_values
+field_name: field_site_theme_values
+entity_type: taxonomy_term
+bundle: sites
+label: 'Theme values'
+description: 'Site theming fields allows adding “key” “value” pairs to apply theming e.g <code>key => rpl-clr-primary,  value => #1c4f9c</code>'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: key_value

--- a/modules/tide_site_theming/config/install/field.storage.taxonomy_term.field_site_feature_flags.yml
+++ b/modules/tide_site_theming/config/install/field.storage.taxonomy_term.field_site_feature_flags.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - key_value_field
+    - taxonomy
+id: taxonomy_term.field_site_feature_flags
+field_name: field_site_feature_flags
+entity_type: taxonomy_term
+type: key_value
+settings:
+  key_max_length: 255
+  key_is_ascii: false
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: key_value_field
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/tide_site_theming/config/install/field.storage.taxonomy_term.field_site_theme_values.yml
+++ b/modules/tide_site_theming/config/install/field.storage.taxonomy_term.field_site_theme_values.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - key_value_field
+    - taxonomy
+id: taxonomy_term.field_site_theme_values
+field_name: field_site_theme_values
+entity_type: taxonomy_term
+type: key_value
+settings:
+  key_max_length: 255
+  key_is_ascii: false
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: key_value_field
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/tide_site_theming/tide_site_theming.info.yml
+++ b/modules/tide_site_theming/tide_site_theming.info.yml
@@ -1,0 +1,13 @@
+name: 'Tide Site Theming'
+description: 'Functionality to apply theming to ripple front end.'
+type: module
+package: Tide
+core_version_requirement: ^9 || ^10
+dependencies:
+  - dpc-sdp:tide_site
+  - key_value_field:key_value_field
+config_devel:
+  install:
+    - field.field.taxonomy_term.sites.field_site_theme_values
+    - field.storage.taxonomy_term.field_site_theme_values
+  optional: { }

--- a/modules/tide_site_theming/tide_site_theming.install
+++ b/modules/tide_site_theming/tide_site_theming.install
@@ -108,7 +108,7 @@ function tide_site_theming_install() {
     ->getStorage('entity_view_display')
     ->load('taxonomy_term.sites.default');
   if ($entity_view_display) {
-    $entity_view_display->setComponent('field_site_twitter_image', [
+    $entity_view_display->setComponent('field_site_theme_values', [
       'type' => 'key_value',
       'weight' => 16,
       'label' => 'above',
@@ -117,14 +117,7 @@ function tide_site_theming_install() {
         'value_only' => FALSE,
       ],
       'third_party_settings' => [],
-    ]);
-  }
-  $entity_view_display->save();
-
-  $entity_view_display = Drupal::entityTypeManager()
-    ->getStorage('entity_view_display')
-    ->load('taxonomy_term.sites.default');
-  if ($entity_view_display) {
+    ])->save();
     $entity_view_display->setComponent('field_site_feature_flags', [
       'type' => 'key_value',
       'weight' => 17,
@@ -134,9 +127,8 @@ function tide_site_theming_install() {
         'value_only' => FALSE,
       ],
       'third_party_settings' => [],
-    ]);
+    ])->save();
   }
-  $entity_view_display->save();
 
   // Grant view preview links block to default roles from tide_core.
   /** @var \Drupal\user\RoleInterface $role */

--- a/modules/tide_site_theming/tide_site_theming.install
+++ b/modules/tide_site_theming/tide_site_theming.install
@@ -57,6 +57,52 @@ function tide_site_theming_install() {
   }
   $entity_form_display->save();
 
+  /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface $entity_form_display */
+  $entity_form_display = \Drupal::entityTypeManager()
+    ->getStorage('entity_form_display')
+    ->load('taxonomy_term.sites.default');
+  if ($entity_form_display) {
+    $entity_form_display->setComponent('field_site_feature_flags', [
+      'type' => 'key_value_textfield',
+      'weight' => 19,
+      'region' => 'content',
+      'settings' => [
+        'size' => 60,
+        'placeholder' => '',
+        'key_label' => 'Key',
+        'value_label' => 'Value',
+        'description_label' => 'Description',
+        'description_rows' => 5,
+        'key_size' => 60,
+        'key_placeholder' => '',
+        'description_enabled' => FALSE,
+        'description_placeholder' => '',
+      ],
+      'third_party_settings' => [],
+    ]);
+    $field_group = $entity_form_display->getThirdPartySettings('field_group');
+    $field_group['group_site_feature_flag_values'] = [
+      'children' => [
+        'field_site_feature_flags',
+      ],
+      'parent_name' => '',
+      'label' => 'Site feature flag values',
+      'weight' => 18,
+      'format_type' => 'details',
+      'region' => 'content',
+      'format_settings' => [
+        'classes' => '',
+        'show_empty_fields' => FALSE,
+        'id' => 'tide-feature-flag-fields',
+        'open' => FALSE,
+        'required_fields' => TRUE,
+        'effect' => 'none',
+      ],
+    ];
+    $entity_form_display->setThirdPartySetting('field_group', 'group_site_feature_flag_values', $field_group['group_site_feature_flag_values']);
+  }
+  $entity_form_display->save();
+
   // Adding the field to display view.
   $entity_view_display = Drupal::entityTypeManager()
     ->getStorage('entity_view_display')
@@ -65,6 +111,23 @@ function tide_site_theming_install() {
     $entity_view_display->setComponent('field_site_twitter_image', [
       'type' => 'key_value',
       'weight' => 16,
+      'label' => 'above',
+      'region' => 'content',
+      'settings' => [
+        'value_only' => FALSE,
+      ],
+      'third_party_settings' => [],
+    ]);
+  }
+  $entity_view_display->save();
+
+  $entity_view_display = Drupal::entityTypeManager()
+    ->getStorage('entity_view_display')
+    ->load('taxonomy_term.sites.default');
+  if ($entity_view_display) {
+    $entity_view_display->setComponent('field_site_feature_flags', [
+      'type' => 'key_value',
+      'weight' => 17,
       'label' => 'above',
       'region' => 'content',
       'settings' => [
@@ -84,18 +147,23 @@ function tide_site_theming_install() {
   // Add to JSON.
   $config_factory = \Drupal::configFactory();
   $config = $config_factory->getEditable('jsonapi_extras.jsonapi_resource_config.taxonomy_term--sites');
-
+  $resourcefields_fields = [
+    'field_site_theme_values',
+    'field_site_feature_flags',
+  ];
   $content = $config->get('resourceFields');
-  if (!isset($content['field_site_theme_values'])) {
-    $content['field_site_theme_values'] = [
-      'fieldName' => 'field_site_theme_values',
-      'publicName' => 'field_site_theme_values',
-      'enhancer' => [
-        'id' => '',
-      ],
-      'disabled' => FALSE,
-    ];
-    $config->set('resourceFields', $content);
+  foreach ($resourcefields_fields as $field) {
+    if (!isset($content[$field])) {
+      $content[$field] = [
+        'fieldName' => $field,
+        'publicName' => $field,
+        'enhancer' => [
+          'id' => '',
+        ],
+        'disabled' => FALSE,
+      ];
+      $config->set('resourceFields', $content);
+    }
   }
   $config->save();
 }

--- a/modules/tide_site_theming/tide_site_theming.install
+++ b/modules/tide_site_theming/tide_site_theming.install
@@ -10,7 +10,6 @@ use Drupal\user\Entity\Role;
 /**
  * Implements hook_install().
  */
-
 function tide_site_theming_install() {
   /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface $entity_form_display */
   $entity_form_display = \Drupal::entityTypeManager()
@@ -71,7 +70,7 @@ function tide_site_theming_install() {
       'settings' => [
         'value_only' => FALSE,
       ],
-      'third_party_settings' => []
+      'third_party_settings' => [],
     ]);
   }
   $entity_view_display->save();

--- a/modules/tide_site_theming/tide_site_theming.install
+++ b/modules/tide_site_theming/tide_site_theming.install
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * @file
+ * Install file.
+ */
+
+
+/**
+ * Implements hook_install().
+ */
+function tide_site_theming_install() {
+  /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface $entity_form_display */
+  $entity_form_display = \Drupal::entityTypeManager()
+    ->getStorage('entity_form_display')
+    ->load('taxonomy_term.sites.default');
+  if ($entity_form_display) {
+    $entity_form_display->setComponent('field_site_theme_values', [
+      'type' => 'key_value_textfield',
+      'weight' => 18,
+      'region' => 'content',
+      'settings' => [
+        'size' => 60,
+        'placeholder' => '',
+        'key_label' => 'Key',
+        'value_label' => 'Value',
+        'description_label' => 'Description',
+        'description_rows' => 5,
+        'key_size' => 60,
+        'key_placeholder' => '',
+        'description_enabled' => false,
+        'description_placeholder' => '',
+      ],
+      'third_party_settings' => [],
+    ]);
+    $field_group = $entity_form_display->getThirdPartySettings('field_group');
+    $field_group['group_site_theme_values'] = [
+      'children' => [
+        'field_site_theme_values',
+      ],
+      'parent_name' => '',
+      'label' => 'Site theme values',
+      'weight' => 17,
+      'format_type' => 'details',
+      'region' => 'content',
+      'format_settings' => [
+        'classes' => '',
+        'show_empty_fields' => false,
+        'id' => 'tide-site-theming-fileds',
+        'open' => false,
+        'required_fields' => true,
+        'effect' => 'none',
+      ],
+    ];
+    $entity_form_display->setThirdPartySetting('field_group', 'group_site_theme_values', $field_group['group_site_theme_values']);
+  }
+  $entity_form_display->save();
+
+  // Adding the field to display view.
+  $entity_view_display = Drupal::entityTypeManager()
+  ->getStorage('entity_view_display')
+  ->load('taxonomy_term.sites.default');
+  if ($entity_view_display) {
+    $entity_view_display->setComponent('field_site_twitter_image', [
+      'type' => 'key_value',
+      'weight' => 16,
+      'label' => 'above',
+      'region' => 'content',
+      'settings' => [
+        'value_only' => false
+      ],
+      'third_party_settings' => []
+    ]);
+  }
+
+  // Grant view preview links block to default roles from tide_core.
+  /** @var \Drupal\user\RoleInterface $role */
+  $role = Role::load('site_admin');
+  if ($role) {
+    $role->grantPermission('tide site theming')->save();
+  }
+}

--- a/modules/tide_site_theming/tide_site_theming.install
+++ b/modules/tide_site_theming/tide_site_theming.install
@@ -5,10 +5,12 @@
  * Install file.
  */
 
+use Drupal\user\Entity\Role;
 
 /**
  * Implements hook_install().
  */
+
 function tide_site_theming_install() {
   /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface $entity_form_display */
   $entity_form_display = \Drupal::entityTypeManager()
@@ -28,7 +30,7 @@ function tide_site_theming_install() {
         'description_rows' => 5,
         'key_size' => 60,
         'key_placeholder' => '',
-        'description_enabled' => false,
+        'description_enabled' => FALSE,
         'description_placeholder' => '',
       ],
       'third_party_settings' => [],
@@ -45,10 +47,10 @@ function tide_site_theming_install() {
       'region' => 'content',
       'format_settings' => [
         'classes' => '',
-        'show_empty_fields' => false,
+        'show_empty_fields' => FALSE,
         'id' => 'tide-site-theming-fileds',
-        'open' => false,
-        'required_fields' => true,
+        'open' => FALSE,
+        'required_fields' => TRUE,
         'effect' => 'none',
       ],
     ];
@@ -58,8 +60,8 @@ function tide_site_theming_install() {
 
   // Adding the field to display view.
   $entity_view_display = Drupal::entityTypeManager()
-  ->getStorage('entity_view_display')
-  ->load('taxonomy_term.sites.default');
+    ->getStorage('entity_view_display')
+    ->load('taxonomy_term.sites.default');
   if ($entity_view_display) {
     $entity_view_display->setComponent('field_site_twitter_image', [
       'type' => 'key_value',
@@ -67,7 +69,7 @@ function tide_site_theming_install() {
       'label' => 'above',
       'region' => 'content',
       'settings' => [
-        'value_only' => false
+        'value_only' => FALSE,
       ],
       'third_party_settings' => []
     ]);

--- a/modules/tide_site_theming/tide_site_theming.install
+++ b/modules/tide_site_theming/tide_site_theming.install
@@ -72,6 +72,7 @@ function tide_site_theming_install() {
       'third_party_settings' => []
     ]);
   }
+  $entity_view_display->save();
 
   // Grant view preview links block to default roles from tide_core.
   /** @var \Drupal\user\RoleInterface $role */
@@ -79,4 +80,21 @@ function tide_site_theming_install() {
   if ($role) {
     $role->grantPermission('tide site theming')->save();
   }
+  // Add to JSON.
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('jsonapi_extras.jsonapi_resource_config.taxonomy_term--sites');
+
+  $content = $config->get('resourceFields');
+  if (!isset($content['field_site_theme_values'])) {
+    $content['field_site_theme_values'] = [
+      'fieldName' => 'field_site_theme_values',
+      'publicName' => 'field_site_theme_values',
+      'enhancer' => [
+        'id' => '',
+      ],
+      'disabled' => FALSE,
+    ];
+    $config->set('resourceFields', $content);
+  }
+  $config->save();
 }

--- a/modules/tide_site_theming/tide_site_theming.module
+++ b/modules/tide_site_theming/tide_site_theming.module
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ * Tide Site Theming module .
+ */
+
+/**
+ * Implements hook_field_group_form_process_alter().
+ */
+function tide_site_theming_field_group_form_process_alter(array &$element, &$group, &$complete_form) {
+    // Grant a
+    if ($element['#id'] == 'tide-site-theming-fileds') {
+      $user = \Drupal::currentUser();
+      $access_tide_site_theming_fields = 'tide site theming';
+      if (!$user->hasPermission($access_tide_site_theming_fields)) {
+        $element['#access'] = FALSE;
+        return;
+      }
+    }
+  }

--- a/modules/tide_site_theming/tide_site_theming.module
+++ b/modules/tide_site_theming/tide_site_theming.module
@@ -9,13 +9,13 @@
  * Implements hook_field_group_form_process_alter().
  */
 function tide_site_theming_field_group_form_process_alter(array &$element, &$group, &$complete_form) {
-    // Grant a
-    if ($element['#id'] == 'tide-site-theming-fileds') {
-      $user = \Drupal::currentUser();
-      $access_tide_site_theming_fields = 'tide site theming';
-      if (!$user->hasPermission($access_tide_site_theming_fields)) {
-        $element['#access'] = FALSE;
-        return;
-      }
+  // Grant access to site theming fields.
+  if ($element['#id'] == 'tide-site-theming-fileds') {
+    $user = \Drupal::currentUser();
+    $access_tide_site_theming_fields = 'tide site theming';
+    if (!$user->hasPermission($access_tide_site_theming_fields)) {
+      $element['#access'] = FALSE;
+      return;
     }
   }
+}

--- a/modules/tide_site_theming/tide_site_theming.module
+++ b/modules/tide_site_theming/tide_site_theming.module
@@ -10,7 +10,7 @@
  */
 function tide_site_theming_field_group_form_process_alter(array &$element, &$group, &$complete_form) {
   // Grant access to site theming fields.
-  if ($element['#id'] == 'tide-site-theming-fileds') {
+  if ($element['#id'] == 'tide-site-theming-fileds' || $element['#id'] == 'tide-feature-flag-fields') {
     $user = \Drupal::currentUser();
     $access_tide_site_theming_fields = 'tide site theming';
     if (!$user->hasPermission($access_tide_site_theming_fields)) {

--- a/modules/tide_site_theming/tide_site_theming.permissions.yml
+++ b/modules/tide_site_theming/tide_site_theming.permissions.yml
@@ -1,0 +1,3 @@
+tide site theming:
+  title: 'Access tide site theming fields'
+  description: 'Allow users to access the tide site theming fields in site taxonomy.'


### PR DESCRIPTION
### JIRA
https://digital-vic.atlassian.net/browse/R20-293

### Changes
1. Added new custom module tide_site_theming
2. Adds new key value paired fields in the site taxonomy
3. Added permission to access these fields only by the site_admin

### Note 
Reason behind adding it as a separate module - This module only should be enabled when a BE site using ripple 2.0 at the FE