### PR TITLE
[R20-335] Be able to define site wide "feature flags" from Tide Site config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "require": {
-        "dpc-sdp/tide_core": "dev-feature/SRM-512_update_drupal_to_9.4",
-        "dpc-sdp/tide_media": "dev-feature/SRM-512_update_drupal_to_9.4",
+        "dpc-sdp/tide_core": "^3.1.13",
+        "dpc-sdp/tide_media": "^3.0.8",
         "drupal/create_menus_permission": "^1.0",
         "drupal/key_value_field": "^1.3"
     },

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
-export GH_COMMIT=9dbb1773923a6b5ac95583a21cf1b293a593679a
+# export GH_COMMIT=COMMIT_SHA
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"

--- a/modules/tide_site_theming/config/install/field.field.taxonomy_term.sites.field_site_feature_flags.yml
+++ b/modules/tide_site_theming/config/install/field.field.taxonomy_term.sites.field_site_feature_flags.yml
@@ -1,4 +1,3 @@
-uuid: e6b96cf2-afda-4f42-905f-fec12978a8e8
 langcode: en
 status: true
 dependencies:

--- a/modules/tide_site_theming/config/install/field.field.taxonomy_term.sites.field_site_feature_flags.yml
+++ b/modules/tide_site_theming/config/install/field.field.taxonomy_term.sites.field_site_feature_flags.yml
@@ -1,0 +1,21 @@
+uuid: e6b96cf2-afda-4f42-905f-fec12978a8e8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_site_feature_flags
+    - taxonomy.vocabulary.sites
+  module:
+    - key_value_field
+id: taxonomy_term.sites.field_site_feature_flags
+field_name: field_site_feature_flags
+entity_type: taxonomy_term
+bundle: sites
+label: 'Feature flags'
+description: 'Site feature flag field allows adding “key” “value” pairs to apply feature flag e.g <code>key => footerTheme, value => neutral</code>'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: key_value

--- a/modules/tide_site_theming/config/install/field.storage.taxonomy_term.field_site_feature_flags.yml
+++ b/modules/tide_site_theming/config/install/field.storage.taxonomy_term.field_site_feature_flags.yml
@@ -1,4 +1,3 @@
-uuid: 7252be8a-0d77-4d97-990b-a12e83900205
 langcode: en
 status: true
 dependencies:

--- a/modules/tide_site_theming/config/install/field.storage.taxonomy_term.field_site_feature_flags.yml
+++ b/modules/tide_site_theming/config/install/field.storage.taxonomy_term.field_site_feature_flags.yml
@@ -1,0 +1,24 @@
+uuid: 7252be8a-0d77-4d97-990b-a12e83900205
+langcode: en
+status: true
+dependencies:
+  module:
+    - key_value_field
+    - taxonomy
+id: taxonomy_term.field_site_feature_flags
+field_name: field_site_feature_flags
+entity_type: taxonomy_term
+type: key_value
+settings:
+  key_max_length: 255
+  key_is_ascii: false
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: key_value_field
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/tide_site_theming/tide_site_theming.install
+++ b/modules/tide_site_theming/tide_site_theming.install
@@ -57,6 +57,52 @@ function tide_site_theming_install() {
   }
   $entity_form_display->save();
 
+  /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface $entity_form_display */
+  $entity_form_display = \Drupal::entityTypeManager()
+    ->getStorage('entity_form_display')
+    ->load('taxonomy_term.sites.default');
+  if ($entity_form_display) {
+    $entity_form_display->setComponent('field_site_feature_flags', [
+      'type' => 'key_value_textfield',
+      'weight' => 19,
+      'region' => 'content',
+      'settings' => [
+        'size' => 60,
+        'placeholder' => '',
+        'key_label' => 'Key',
+        'value_label' => 'Value',
+        'description_label' => 'Description',
+        'description_rows' => 5,
+        'key_size' => 60,
+        'key_placeholder' => '',
+        'description_enabled' => FALSE,
+        'description_placeholder' => '',
+      ],
+      'third_party_settings' => [],
+    ]);
+    $field_group = $entity_form_display->getThirdPartySettings('field_group');
+    $field_group['group_site_feature_flag_values'] = [
+      'children' => [
+        'field_site_feature_flags',
+      ],
+      'parent_name' => '',
+      'label' => 'Site feature flag values',
+      'weight' => 18,
+      'format_type' => 'details',
+      'region' => 'content',
+      'format_settings' => [
+        'classes' => '',
+        'show_empty_fields' => FALSE,
+        'id' => 'tide-feature-flag-fields',
+        'open' => FALSE,
+        'required_fields' => TRUE,
+        'effect' => 'none',
+      ],
+    ];
+    $entity_form_display->setThirdPartySetting('field_group', 'group_site_feature_flag_values', $field_group['group_site_feature_flag_values']);
+  }
+  $entity_form_display->save();
+
   // Adding the field to display view.
   $entity_view_display = Drupal::entityTypeManager()
     ->getStorage('entity_view_display')
@@ -75,11 +121,29 @@ function tide_site_theming_install() {
   }
   $entity_view_display->save();
 
+  $entity_view_display = Drupal::entityTypeManager()
+    ->getStorage('entity_view_display')
+    ->load('taxonomy_term.sites.default');
+  if ($entity_view_display) {
+    $entity_view_display->setComponent('field_site_feature_flags', [
+      'type' => 'key_value',
+      'weight' => 17,
+      'label' => 'above',
+      'region' => 'content',
+      'settings' => [
+        'value_only' => FALSE,
+      ],
+      'third_party_settings' => [],
+    ]);
+  }
+  $entity_view_display->save();
+
   // Grant view preview links block to default roles from tide_core.
   /** @var \Drupal\user\RoleInterface $role */
   $role = Role::load('site_admin');
   if ($role) {
     $role->grantPermission('tide site theming')->save();
+    $role->grantPermission('tide site feature flags')->save();
   }
   // Add to JSON.
   $config_factory = \Drupal::configFactory();
@@ -90,6 +154,17 @@ function tide_site_theming_install() {
     $content['field_site_theme_values'] = [
       'fieldName' => 'field_site_theme_values',
       'publicName' => 'field_site_theme_values',
+      'enhancer' => [
+        'id' => '',
+      ],
+      'disabled' => FALSE,
+    ];
+    $config->set('resourceFields', $content);
+  }
+  if (!isset($content['field_site_feature_flags'])) {
+    $content['field_site_feature_flags'] = [
+      'fieldName' => 'field_site_feature_flags',
+      'publicName' => 'field_site_feature_flags',
       'enhancer' => [
         'id' => '',
       ],

--- a/modules/tide_site_theming/tide_site_theming.install
+++ b/modules/tide_site_theming/tide_site_theming.install
@@ -143,34 +143,27 @@ function tide_site_theming_install() {
   $role = Role::load('site_admin');
   if ($role) {
     $role->grantPermission('tide site theming')->save();
-    $role->grantPermission('tide site feature flags')->save();
   }
   // Add to JSON.
   $config_factory = \Drupal::configFactory();
   $config = $config_factory->getEditable('jsonapi_extras.jsonapi_resource_config.taxonomy_term--sites');
-
+  $resourcefields_fields = [
+    'field_site_theme_values',
+    'field_site_feature_flags',
+  ];
   $content = $config->get('resourceFields');
-  if (!isset($content['field_site_theme_values'])) {
-    $content['field_site_theme_values'] = [
-      'fieldName' => 'field_site_theme_values',
-      'publicName' => 'field_site_theme_values',
-      'enhancer' => [
-        'id' => '',
-      ],
-      'disabled' => FALSE,
-    ];
-    $config->set('resourceFields', $content);
-  }
-  if (!isset($content['field_site_feature_flags'])) {
-    $content['field_site_feature_flags'] = [
-      'fieldName' => 'field_site_feature_flags',
-      'publicName' => 'field_site_feature_flags',
-      'enhancer' => [
-        'id' => '',
-      ],
-      'disabled' => FALSE,
-    ];
-    $config->set('resourceFields', $content);
+  foreach ($resourcefields_fields as $field) {
+    if (!isset($content[$field])) {
+      $content[$field] = [
+        'fieldName' => $field,
+        'publicName' => $field,
+        'enhancer' => [
+          'id' => '',
+        ],
+        'disabled' => FALSE,
+      ];
+      $config->set('resourceFields', $content);
+    }
   }
   $config->save();
 }

--- a/modules/tide_site_theming/tide_site_theming.module
+++ b/modules/tide_site_theming/tide_site_theming.module
@@ -10,18 +10,10 @@
  */
 function tide_site_theming_field_group_form_process_alter(array &$element, &$group, &$complete_form) {
   // Grant access to site theming fields.
-  if ($element['#id'] == 'tide-site-theming-fileds') {
+  if ($element['#id'] == 'tide-site-theming-fileds' || $element['#id'] == 'tide-feature-flag-fields') {
     $user = \Drupal::currentUser();
     $access_tide_site_theming_fields = 'tide site theming';
     if (!$user->hasPermission($access_tide_site_theming_fields)) {
-      $element['#access'] = FALSE;
-      return;
-    }
-  }
-  if ($element['#id'] == 'tide-feature-flag-fields') {
-    $user = \Drupal::currentUser();
-    $access_tide_feature_flag_fields = 'tide site feature flags';
-    if (!$user->hasPermission($access_tide_feature_flag_fields)) {
       $element['#access'] = FALSE;
       return;
     }

--- a/modules/tide_site_theming/tide_site_theming.module
+++ b/modules/tide_site_theming/tide_site_theming.module
@@ -18,4 +18,12 @@ function tide_site_theming_field_group_form_process_alter(array &$element, &$gro
       return;
     }
   }
+  if ($element['#id'] == 'tide-feature-flag-fields') {
+    $user = \Drupal::currentUser();
+    $access_tide_feature_flag_fields = 'tide site feature flags';
+    if (!$user->hasPermission($access_tide_feature_flag_fields)) {
+      $element['#access'] = FALSE;
+      return;
+    }
+  }
 }

--- a/modules/tide_site_theming/tide_site_theming.permissions.yml
+++ b/modules/tide_site_theming/tide_site_theming.permissions.yml
@@ -1,6 +1,3 @@
 tide site theming:
   title: 'Access tide site theming fields'
   description: 'Allow users to access the tide site theming fields in site taxonomy.'
-tide site feature flags:
-  title: 'Access tide site feature flags'
-  description: 'Allow users to access the tide site feature flags in site taxonomy.'

--- a/modules/tide_site_theming/tide_site_theming.permissions.yml
+++ b/modules/tide_site_theming/tide_site_theming.permissions.yml
@@ -1,3 +1,6 @@
 tide site theming:
   title: 'Access tide site theming fields'
   description: 'Allow users to access the tide site theming fields in site taxonomy.'
+tide site feature flags:
+  title: 'Access tide site feature flags'
+  description: 'Allow users to access the tide site feature flags in site taxonomy.'


### PR DESCRIPTION
### JIRA
https://digital-vic.atlassian.net/browse/R20-335

BE PR: https://nginx-php.pr-171.content-reference-sdp-vic-gov-au.sdp4.sdp.vic.gov.au/

### Changes:
1. Additional field identical to the tide_site_theming; field_site_theme_values
2. Adds new key value paired fields in the site taxonomy

### Screenshots
![image](https://user-images.githubusercontent.com/67810118/202091908-b7636408-727f-419a-a96f-ea51a44ec749.png)

![image](https://user-images.githubusercontent.com/67810118/202091990-2f7df8d8-10aa-442b-aa63-6195981e9905.png)
