### PR TITLE
[SRM-702] Fix for revision loading throws error on illegal offset type.

### DIFF
--- a/modules/tide_site_preview/src/Plugin/Block/PreviewLinksBlock.php
+++ b/modules/tide_site_preview/src/Plugin/Block/PreviewLinksBlock.php
@@ -233,8 +233,7 @@ class PreviewLinksBlock extends BlockBase implements ContainerFactoryPluginInter
     $node = $this->routeMatch->getParameter('node');
     if ($route_name === 'entity.node.revision') {
       try {
-        $vid = $this->routeMatch->getParameter('node_revision');
-        $node = is_int($vid) ? $this->entityTypeManager->getStorage('node')->loadRevision($vid) : NULL;
+        $node = $this->routeMatch->getParameter('node_revision');
       }
       catch (Exception $exception) {
         watchdog_exception('tide_site_preview', $exception);

--- a/modules/tide_site_preview/src/Plugin/Block/PreviewLinksBlock.php
+++ b/modules/tide_site_preview/src/Plugin/Block/PreviewLinksBlock.php
@@ -234,8 +234,7 @@ class PreviewLinksBlock extends BlockBase implements ContainerFactoryPluginInter
     if ($route_name === 'entity.node.revision') {
       try {
         $vid = $this->routeMatch->getParameter('node_revision');
-        $node = $this->entityTypeManager->getStorage('node')
-          ->loadRevision($vid);
+        $node = is_int($vid) ? $this->entityTypeManager->getStorage('node')->loadRevision($vid) : null;
       }
       catch (Exception $exception) {
         watchdog_exception('tide_site_preview', $exception);

--- a/modules/tide_site_preview/src/Plugin/Block/PreviewLinksBlock.php
+++ b/modules/tide_site_preview/src/Plugin/Block/PreviewLinksBlock.php
@@ -234,7 +234,7 @@ class PreviewLinksBlock extends BlockBase implements ContainerFactoryPluginInter
     if ($route_name === 'entity.node.revision') {
       try {
         $vid = $this->routeMatch->getParameter('node_revision');
-        $node = is_int($vid) ? $this->entityTypeManager->getStorage('node')->loadRevision($vid) : null;
+        $node = is_int($vid) ? $this->entityTypeManager->getStorage('node')->loadRevision($vid) : NULL;
       }
       catch (Exception $exception) {
         watchdog_exception('tide_site_preview', $exception);


### PR DESCRIPTION
### JIRA
https://digital-vic.atlassian.net/browse/SRM-702

### Issue
Some of the $vid values returned as object and which causes illegal offset type error when calling the `loadRevision` function.
Scenario - Go to a node in any CMS and click on the revision tab. Then click on any previous revision and then the CMS will throw error.

### Changes
9.4 returns the vid directly from here - `$revision = $this->routeMatch->getParameter('node_revision');`
https://github.com/dpc-sdp/tide_site/issues/121