### PR TITLE
[SDPAP-7999] Fixing update hook to not to change existing settings during update.

### DIFF
--- a/modules/tide_site_theming/src/TideSiteThemingOperation.php
+++ b/modules/tide_site_theming/src/TideSiteThemingOperation.php
@@ -1,0 +1,295 @@
+<?php
+
+namespace Drupal\tide_site_theming;
+
+use Drupal\user\Entity\Role;
+
+/**
+ * Required changes to form and view display.
+ */
+class TideSiteThemingOperation {
+
+  /**
+   * Add necissary changes to the form and view display.
+   */
+  public function requiredChangesForTheming() {
+    // Update entity form display.
+    $entity_form_display = \Drupal::entityTypeManager()
+      ->getStorage('entity_form_display')
+      ->load('taxonomy_term.sites.default');
+    if ($entity_form_display) {
+      // Set field_site_theme_values.
+      $entity_form_display->setComponent('field_site_theme_values', [
+        'type' => 'key_value_textfield',
+        'weight' => 18,
+        'region' => 'content',
+        'settings' => [
+          'size' => 60,
+          'placeholder' => '',
+          'key_label' => 'Key',
+          'value_label' => 'Value',
+          'description_label' => 'Description',
+          'description_rows' => 5,
+          'key_size' => 60,
+          'key_placeholder' => '',
+          'description_enabled' => FALSE,
+          'description_placeholder' => '',
+        ],
+        'third_party_settings' => [],
+      ]);
+      $field_group = $entity_form_display->getThirdPartySettings('field_group');
+      $field_group['group_site_theme_values'] = [
+        'children' => [
+          'field_site_theme_values',
+        ],
+        'parent_name' => '',
+        'label' => 'Site theme values',
+        'weight' => 17,
+        'format_type' => 'details',
+        'region' => 'content',
+        'format_settings' => [
+          'classes' => '',
+          'show_empty_fields' => FALSE,
+          'id' => 'tide-site-theming-fileds',
+          'open' => FALSE,
+          'required_fields' => TRUE,
+          'effect' => 'none',
+        ],
+      ];
+      $entity_form_display->setThirdPartySetting('field_group', 'group_site_theme_values', $field_group['group_site_theme_values']);
+
+      // Set field_site_feature_flags.
+      $entity_form_display->setComponent('field_site_feature_flags', [
+        'type' => 'key_value_textfield',
+        'weight' => 19,
+        'region' => 'content',
+        'settings' => [
+          'size' => 60,
+          'placeholder' => '',
+          'key_label' => 'Key',
+          'value_label' => 'Value',
+          'description_label' => 'Description',
+          'description_rows' => 5,
+          'key_size' => 60,
+          'key_placeholder' => '',
+          'description_enabled' => FALSE,
+          'description_placeholder' => '',
+        ],
+        'third_party_settings' => [],
+      ]);
+      $field_group = $entity_form_display->getThirdPartySettings('field_group');
+      $field_group['group_site_feature_flag_values'] = [
+        'children' => [
+          'field_site_feature_flags',
+        ],
+        'parent_name' => '',
+        'label' => 'Site feature flag values',
+        'weight' => 18,
+        'format_type' => 'details',
+        'region' => 'content',
+        'format_settings' => [
+          'classes' => '',
+          'show_empty_fields' => FALSE,
+          'id' => 'tide-feature-flag-fields',
+          'open' => FALSE,
+          'required_fields' => TRUE,
+          'effect' => 'none',
+        ],
+      ];
+      $entity_form_display->setThirdPartySetting('field_group', 'group_site_feature_flag_values', $field_group['group_site_feature_flag_values']);
+
+      // Adds favicon.
+      $entity_form_display->setComponent('field_site_favicon', [
+        'type' => 'image_image',
+        'weight' => 20,
+        'region' => 'content',
+        'settings' => [
+          'progress_indicator' => 'throbber',
+          'preview_image_style' => 'thumbnail',
+        ],
+        'third_party_settings' => [],
+      ]);
+      $field_group = $entity_form_display->getThirdPartySettings('field_group');
+      $field_group['group_site_favicon_value'] = [
+        'children' => [
+          'field_site_favicon',
+        ],
+        'parent_name' => '',
+        'label' => 'Site favicon value',
+        'weight' => 19,
+        'format_type' => 'details',
+        'region' => 'content',
+        'format_settings' => [
+          'classes' => '',
+          'show_empty_fields' => FALSE,
+          'id' => 'tide-site-favicon-field',
+          'open' => FALSE,
+          'required_fields' => TRUE,
+          'effect' => 'none',
+        ],
+      ];
+      $entity_form_display->setThirdPartySetting('field_group', 'group_site_favicon_value', $field_group['group_site_favicon_value']);
+
+      // Adds header corner graphics.
+      $entity_form_display->setComponent('field_top_corner_graphic', [
+        'type' => 'image_image',
+        'weight' => 22,
+        'region' => 'content',
+        'settings' => [
+          'progress_indicator' => 'throbber',
+          'preview_image_style' => 'thumbnail',
+        ],
+        'third_party_settings' => [],
+      ]);
+      $entity_form_display->setComponent('field_bottom_corner_graphic', [
+        'type' => 'image_image',
+        'weight' => 23,
+        'region' => 'content',
+        'settings' => [
+          'progress_indicator' => 'throbber',
+          'preview_image_style' => 'thumbnail',
+        ],
+        'third_party_settings' => [],
+      ]);
+      $field_group = $entity_form_display->getThirdPartySettings('field_group');
+      $field_group['group_site_header_corner_graphic'] = [
+        'children' => [
+          'field_top_corner_graphic',
+          'field_bottom_corner_graphic',
+        ],
+        'parent_name' => '',
+        'label' => 'Site header corner graphics',
+        'weight' => 21,
+        'format_type' => 'details',
+        'region' => 'content',
+        'format_settings' => [
+          'classes' => '',
+          'show_empty_fields' => FALSE,
+          'id' => 'tide-site-header-corner-graphics',
+          'open' => FALSE,
+          'required_fields' => TRUE,
+          'effect' => 'none',
+        ],
+      ];
+      $entity_form_display->setThirdPartySetting('field_group', 'group_site_header_corner_graphic', $field_group['group_site_header_corner_graphic']);
+    }
+    $entity_form_display->save();
+
+    // Adding the field to display view.
+    $entity_view_display = Drupal::entityTypeManager()
+      ->getStorage('entity_view_display')
+      ->load('taxonomy_term.sites.default');
+    if ($entity_view_display) {
+      $entity_view_display->setComponent('field_site_theme_values', [
+        'type' => 'key_value',
+        'weight' => 16,
+        'label' => 'above',
+        'region' => 'content',
+        'settings' => [
+          'value_only' => FALSE,
+        ],
+        'third_party_settings' => [],
+      ])->save();
+      $entity_view_display->setComponent('field_site_feature_flags', [
+        'type' => 'key_value',
+        'weight' => 17,
+        'label' => 'above',
+        'region' => 'content',
+        'settings' => [
+          'value_only' => FALSE,
+        ],
+        'third_party_settings' => [],
+      ])->save();
+      $entity_view_display->setComponent('field_site_favicon', [
+        'type' => 'image',
+        'weight' => 18,
+        'label' => 'above',
+        'region' => 'content',
+        'settings' => [
+          'image_link' => '',
+          'image_style' => '',
+          'svg_attributes' => [
+            'width' => NULL,
+            'height' => NULL,
+          ],
+          'svg_render_as_image' => TRUE,
+          'image_loading' => [
+            'attribute' => 'lazy',
+          ],
+        ],
+        'third_party_settings' => [],
+      ])->save();
+      $entity_view_display->setComponent('field_top_corner_graphic', [
+        'type' => 'image',
+        'weight' => 19,
+        'label' => 'above',
+        'region' => 'content',
+        'settings' => [
+          'image_link' => '',
+          'image_style' => '',
+          'svg_attributes' => [
+            'width' => NULL,
+            'height' => NULL,
+          ],
+          'svg_render_as_image' => TRUE,
+          'image_loading' => [
+            'attribute' => 'lazy',
+          ],
+        ],
+        'third_party_settings' => [],
+      ])->save();
+      $entity_view_display->setComponent('field_bottom_corner_graphic', [
+        'type' => 'image',
+        'weight' => 20,
+        'label' => 'above',
+        'region' => 'content',
+        'settings' => [
+          'image_link' => '',
+          'image_style' => '',
+          'svg_attributes' => [
+            'width' => NULL,
+            'height' => NULL,
+          ],
+          'svg_render_as_image' => TRUE,
+          'image_loading' => [
+            'attribute' => 'lazy',
+          ],
+        ],
+        'third_party_settings' => [],
+      ])->save();
+    }
+
+    // Grant view preview links block to default roles from tide_core.
+    /** @var \Drupal\user\RoleInterface $role */
+    $role = Role::load('site_admin');
+    if ($role) {
+      $role->grantPermission('tide site theming')->save();
+    }
+    // Add to JSON.
+    $config_factory = \Drupal::configFactory();
+    $config = $config_factory->getEditable('jsonapi_extras.jsonapi_resource_config.taxonomy_term--sites');
+    $resourcefields_fields = [
+      'field_site_theme_values',
+      'field_site_feature_flags',
+      'field_site_favicon',
+      'field_top_corner_graphic',
+      'field_bottom_corner_graphic',
+    ];
+    $content = $config->get('resourceFields');
+    foreach ($resourcefields_fields as $field) {
+      if (!isset($content[$field])) {
+        $content[$field] = [
+          'fieldName' => $field,
+          'publicName' => $field,
+          'enhancer' => [
+            'id' => '',
+          ],
+          'disabled' => FALSE,
+        ];
+        $config->set('resourceFields', $content);
+      }
+    }
+    $config->save();
+  }
+
+}

--- a/modules/tide_site_theming/tide_site_theming.install
+++ b/modules/tide_site_theming/tide_site_theming.install
@@ -5,159 +5,19 @@
  * Install file.
  */
 
-use Drupal\user\Entity\Role;
+use Drupal\tide_site_theming\TideSiteThemingOperation;
 
 /**
  * Implements hook_install().
  */
 function tide_site_theming_install() {
-  /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface $entity_form_display */
-  $entity_form_display = \Drupal::entityTypeManager()
-    ->getStorage('entity_form_display')
-    ->load('taxonomy_term.sites.default');
-  if ($entity_form_display) {
-    $entity_form_display->setComponent('field_site_theme_values', [
-      'type' => 'key_value_textfield',
-      'weight' => 18,
-      'region' => 'content',
-      'settings' => [
-        'size' => 60,
-        'placeholder' => '',
-        'key_label' => 'Key',
-        'value_label' => 'Value',
-        'description_label' => 'Description',
-        'description_rows' => 5,
-        'key_size' => 60,
-        'key_placeholder' => '',
-        'description_enabled' => FALSE,
-        'description_placeholder' => '',
-      ],
-      'third_party_settings' => [],
-    ]);
-    $field_group = $entity_form_display->getThirdPartySettings('field_group');
-    $field_group['group_site_theme_values'] = [
-      'children' => [
-        'field_site_theme_values',
-      ],
-      'parent_name' => '',
-      'label' => 'Site theme values',
-      'weight' => 17,
-      'format_type' => 'details',
-      'region' => 'content',
-      'format_settings' => [
-        'classes' => '',
-        'show_empty_fields' => FALSE,
-        'id' => 'tide-site-theming-fileds',
-        'open' => FALSE,
-        'required_fields' => TRUE,
-        'effect' => 'none',
-      ],
-    ];
-    $entity_form_display->setThirdPartySetting('field_group', 'group_site_theme_values', $field_group['group_site_theme_values']);
-  }
-  $entity_form_display->save();
-
-  /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface $entity_form_display */
-  $entity_form_display = \Drupal::entityTypeManager()
-    ->getStorage('entity_form_display')
-    ->load('taxonomy_term.sites.default');
-  if ($entity_form_display) {
-    $entity_form_display->setComponent('field_site_feature_flags', [
-      'type' => 'key_value_textfield',
-      'weight' => 19,
-      'region' => 'content',
-      'settings' => [
-        'size' => 60,
-        'placeholder' => '',
-        'key_label' => 'Key',
-        'value_label' => 'Value',
-        'description_label' => 'Description',
-        'description_rows' => 5,
-        'key_size' => 60,
-        'key_placeholder' => '',
-        'description_enabled' => FALSE,
-        'description_placeholder' => '',
-      ],
-      'third_party_settings' => [],
-    ]);
-    $field_group = $entity_form_display->getThirdPartySettings('field_group');
-    $field_group['group_site_feature_flag_values'] = [
-      'children' => [
-        'field_site_feature_flags',
-      ],
-      'parent_name' => '',
-      'label' => 'Site feature flag values',
-      'weight' => 18,
-      'format_type' => 'details',
-      'region' => 'content',
-      'format_settings' => [
-        'classes' => '',
-        'show_empty_fields' => FALSE,
-        'id' => 'tide-feature-flag-fields',
-        'open' => FALSE,
-        'required_fields' => TRUE,
-        'effect' => 'none',
-      ],
-    ];
-    $entity_form_display->setThirdPartySetting('field_group', 'group_site_feature_flag_values', $field_group['group_site_feature_flag_values']);
-  }
-  $entity_form_display->save();
-
-  // Adding the field to display view.
-  $entity_view_display = Drupal::entityTypeManager()
-    ->getStorage('entity_view_display')
-    ->load('taxonomy_term.sites.default');
-  if ($entity_view_display) {
-    $entity_view_display->setComponent('field_site_theme_values', [
-      'type' => 'key_value',
-      'weight' => 16,
-      'label' => 'above',
-      'region' => 'content',
-      'settings' => [
-        'value_only' => FALSE,
-      ],
-      'third_party_settings' => [],
-    ])->save();
-    $entity_view_display->setComponent('field_site_feature_flags', [
-      'type' => 'key_value',
-      'weight' => 17,
-      'label' => 'above',
-      'region' => 'content',
-      'settings' => [
-        'value_only' => FALSE,
-      ],
-      'third_party_settings' => [],
-    ])->save();
+  // Don't do anything else during config sync.
+  if (\Drupal::isConfigSyncing()) {
+    return;
   }
 
-  // Grant view preview links block to default roles from tide_core.
-  /** @var \Drupal\user\RoleInterface $role */
-  $role = Role::load('site_admin');
-  if ($role) {
-    $role->grantPermission('tide site theming')->save();
-  }
-  // Add to JSON.
-  $config_factory = \Drupal::configFactory();
-  $config = $config_factory->getEditable('jsonapi_extras.jsonapi_resource_config.taxonomy_term--sites');
-  $resourcefields_fields = [
-    'field_site_theme_values',
-    'field_site_feature_flags',
-  ];
-  $content = $config->get('resourceFields');
-  foreach ($resourcefields_fields as $field) {
-    if (!isset($content[$field])) {
-      $content[$field] = [
-        'fieldName' => $field,
-        'publicName' => $field,
-        'enhancer' => [
-          'id' => '',
-        ],
-        'disabled' => FALSE,
-      ];
-      $config->set('resourceFields', $content);
-    }
-  }
-  $config->save();
+  $themingoperation = new TideSiteThemingOperation();
+  $themingoperation->requiredChangesForTheming();
 }
 
 /**

--- a/tide_site.install
+++ b/tide_site.install
@@ -5,7 +5,6 @@
  * Install file for tide_site.
  */
 
-use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
 use Drupal\Core\Site\Settings;
@@ -690,43 +689,39 @@ function tide_site_update_8026() {
       $config_entity->save();
     }
   }
-  $update_configs = [
-    'core.entity_view_display.taxonomy_term.sites.default' => 'entity_view_display',
-    'core.entity_form_display.taxonomy_term.sites.default' => 'entity_form_display',
-  ];
-  $skipped_settings = [
-    'uuid',
-    'langcode',
-    'status',
-    '_core',
-    'id',
-    'field_name',
-    'entity_type',
-    'bundle',
-    'label',
-    'description',
-    'required',
-    'translatable',
-    'field_type',
-  ];
-  foreach ($update_configs as $update_config => $type) {
-    $config_read = _tide_read_config($update_config, $config_location, FALSE);
-    $config = \Drupal::configFactory()->getEditable($update_config);
-    if (!$config) {
-      continue;
-    }
-    $data = $config->getRawData();
-    foreach ($config_read as $key => $item) {
-      if (in_array($key, $skipped_settings)) {
-        continue;
-      }
-      NestedArray::setValue($data, [
-        $key,
-      ], NestedArray::getValue($config_read, [
-        $key,
-      ]));
-    }
-    $config->setData($data)->save();
+
+  /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface $entity_form_display */
+  $entity_form_display = \Drupal::entityTypeManager()
+    ->getStorage('entity_form_display')
+    ->load('taxonomy_term.sites.default');
+  if ($entity_form_display) {
+    $entity_form_display->setComponent('field_print_friendly_logo', [
+      'type' => 'file_generic',
+      'weight' => 3,
+      'region' => 'content',
+      'settings' => [
+        'progress_indicator' => 'throbber',
+      ],
+      'third_party_settings' => [],
+    ]);
+  }
+  $entity_form_display->save();
+
+  // Adding the field to display view.
+  $entity_view_display = Drupal::entityTypeManager()
+    ->getStorage('entity_view_display')
+    ->load('taxonomy_term.sites.default');
+  if ($entity_view_display) {
+    $entity_view_display->setComponent('field_print_friendly_logo', [
+      'type' => 'file_default',
+      'weight' => 2,
+      'label' => 'above',
+      'region' => 'content',
+      'settings' => [
+        'use_description_as_link_text' => TRUE,
+      ],
+      'third_party_settings' => [],
+    ])->save();
   }
 
   $config_factory = \Drupal::configFactory();


### PR DESCRIPTION
### JIRA
https://digital-vic.atlassian.net/browse/SDPAP-7999

### Issue
The print logo update hook was not checking the existing sync directory settings, instead it was taking all the configs from the config install and updating the form and view display. This ended up removing the changes made by the submodule into the view and form display.

### Changes
1. Updated the hook to use better way to set a new component in an existing view and form display. (This will avoid removing any custom or any changes made by other module in the same view or form display )
2. Update tide_site_theming module to add the new update hook changes into the install hook and also separating the install operation in a class function.