### PR TITLE
[SDPAP-7999] Updated the hook to check the existing cofig id properly.

### DIFF
--- a/tide_site.install
+++ b/tide_site.install
@@ -683,7 +683,7 @@ function tide_site_update_8026() {
   foreach ($configs as $config => $type) {
     $config_read = _tide_read_config($config, $config_location, TRUE);
     $storage = \Drupal::entityTypeManager()->getStorage($type);
-    $id = substr($config, strrpos($config, '.') + 1);
+    $id = $storage->getIDFromConfigName($config, $storage->getEntityType()->getConfigPrefix());
     if ($storage->load($id) == NULL) {
       $config_entity = $storage->createFromStorageRecord($config_read);
       $config_entity->save();


### PR DESCRIPTION
### Issue
This error show up during cofig-export in ci build.
```
[error]  'field_storage_config' entity with ID 'taxonomy_term.field_print_friendly_logo' already exists. 
>  [error]  Update failed: tide_site_update_8026
```

### Changes
Updated the id check process.