### PR TITLE
[SDPAP-7814] Added missig term reference.

### DIFF
--- a/src/Commands/TideSiteCommands.php
+++ b/src/Commands/TideSiteCommands.php
@@ -3,6 +3,7 @@
 namespace Drupal\tide_site\Commands;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\taxonomy\Entity\Term;
 use Drush\Commands\DrushCommands;
 
 /**


### PR DESCRIPTION
### JIRA
https://digital-vic.atlassian.net/browse/SDPAP-7814

### Issue
The drush command function missing the Term class reference.

### Changes
Added the missing term use statement and the command is compatible with drush command, still works perfectly.

### Related PR
Added the changes in the tide-platform lagoon yml template to roll out the missing drush command for all SDP projects.
https://github.com/dpc-sdp/ansible-role-sdp-tide-platform/pull/82

### Screenshot
![Screenshot 2023-10-23 at 4 58 10 pm](https://github.com/dpc-sdp/tide_site/assets/20810541/34c5eaa2-f900-4732-959d-fa63711d03e1)
