### PR TITLE
Added null check.

### DIFF
--- a/src/Commands/TideSiteCommands.php
+++ b/src/Commands/TideSiteCommands.php
@@ -48,7 +48,8 @@ class TideSiteCommands extends DrushCommands {
             if ($term) {
               $term->set('field_site_domains', str_replace('<br/>', "\r\n", $domain[1]));
               $term->save();
-            } else {
+            } 
+            else {
               $this->output()->writeln($this->t('Term with ID @term_id not found.', ['@term_id' => $domain[0]]));
             }
           }

--- a/src/Commands/TideSiteCommands.php
+++ b/src/Commands/TideSiteCommands.php
@@ -44,8 +44,13 @@ class TideSiteCommands extends DrushCommands {
           foreach (explode(',', $fe_domains) as $fe_domain) {
             $domain = explode('|', $fe_domain);
             $term = Term::load($domain[0]);
-            $term->set('field_site_domains', str_replace('<br/>', "\r\n", $domain[1]));
-            $term->save();
+            // Check if the term exists before trying to manipulate it.
+            if ($term) {
+              $term->set('field_site_domains', str_replace('<br/>', "\r\n", $domain[1]));
+              $term->save();
+            } else {
+              $this->output()->writeln($this->t('Term with ID @term_id not found.', ['@term_id' => $domain[0]]));
+            }
           }
           $this->output()->writeln($this->t('Domains Updated.'));
         }

--- a/src/Commands/TideSiteCommands.php
+++ b/src/Commands/TideSiteCommands.php
@@ -48,7 +48,7 @@ class TideSiteCommands extends DrushCommands {
             if ($term) {
               $term->set('field_site_domains', str_replace('<br/>', "\r\n", $domain[1]));
               $term->save();
-            } 
+            }
             else {
               $this->output()->writeln($this->t('Term with ID @term_id not found.', ['@term_id' => $domain[0]]));
             }


### PR DESCRIPTION
### Issue
The content reference site does not have the site id created. It only gets created when the demo content gets enabled. The demo site id is 8888 and that is what has been used for the reference site FE. This is causing issue when running the drush command to update the domains. The drush command when it was written, there wasn't any scenario like this but now it is once exceptional scenario only for reference site.

### Changes
Added a term check on the drush command, so that it does not break the build for the reference site.