### PR TITLE
[SDPAP-8375]grant permission to approver to create/update terms in sites

### DIFF
--- a/tide_site.install
+++ b/tide_site.install
@@ -28,7 +28,7 @@ function tide_site_update_10000() {
   $permissions = [
     'create terms in sites',
     'edit terms in sites',
-    ];
+  ];
   if ($approver) {
     foreach ($permissions as $permission) {
       $approver->grantPermission($permission);

--- a/tide_site.install
+++ b/tide_site.install
@@ -5,6 +5,8 @@
  * Install file for tide_site.
  */
 
+ use Drupal\user\Entity\Role;
+
 /**
  * Implements hook_install().
  */
@@ -15,5 +17,16 @@ function tide_site_install() {
     foreach (array_keys($bundles) as $bundle) {
       tide_site_entity_bundle_create($type, $bundle);
     }
+  }
+}
+
+/**
+ * Approver should have permission to create/edit terms in sites.
+ */
+function tide_site_update_10000() {
+  $approver = Role::load('approver');
+  if ($approver) {
+    $approver->grantPermission('create terms in sites', 'edit terms in sites');
+    $approver->save();
   }
 }

--- a/tide_site.install
+++ b/tide_site.install
@@ -25,8 +25,14 @@ function tide_site_install() {
  */
 function tide_site_update_10000() {
   $approver = Role::load('approver');
+  $permissions = [
+    'create terms in sites',
+    'edit terms in sites',
+    ];
   if ($approver) {
-    $approver->grantPermission('create terms in sites', 'edit terms in sites');
+    foreach ($permissions as $permission) {
+      $approver->grantPermission($permission);
+    }
     $approver->save();
   }
 }

--- a/tide_site.install
+++ b/tide_site.install
@@ -5,7 +5,7 @@
  * Install file for tide_site.
  */
 
- use Drupal\user\Entity\Role;
+use Drupal\user\Entity\Role;
 
 /**
  * Implements hook_install().


### PR DESCRIPTION
https://digital-vic.atlassian.net/browse/SDPAP-8375
Testing link: https://nginx-php.pr-352.content-reference-sdp-vic-gov-au.sdp4.sdp.vic.gov.au/
### Problem/Motivation
Approvers shouldn’t be able to create/edit any taxonomy terms except Department and Sites, and shouldn’t be able to delete any taxonomy terms.
### Fix
Grant permission to create and edit sites.
**RELATED PR:** 
https://github.com/dpc-sdp/tide_core/pull/453
Remove permissions such as administer taxonomy.
Grant permissions to create and edit terms in department.
![Screenshot 2023-12-06 at 1 53 30 pm](https://github.com/dpc-sdp/tide_site/assets/47239456/e9c5d3ce-e811-4595-b18e-9149ab2f64ea)
