### PR TITLE
[SDPAP-8510] Sitemap doesn't create the custom URL automatically in UI

### DIFF
--- a/modules/tide_site_simple_sitemap/tide_site_simple_sitemap.module
+++ b/modules/tide_site_simple_sitemap/tide_site_simple_sitemap.module
@@ -7,6 +7,7 @@
 
 use Drupal\simple_sitemap\Entity\SimpleSitemap;
 use Drupal\simple_sitemap\Entity\SimpleSitemapInterface;
+use Drupal\taxonomy\Entity\Term;
 
 /**
  * Implements hook_ENTITY_TYPE_delete().
@@ -28,4 +29,35 @@ function tide_site_simple_sitemap_taxonomy_term_delete($term) {
   catch (Exception $exception) {
     watchdog_exception('tide_site_simple_sitemap', $exception);
   }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_insert().
+ */
+function tide_site_simple_sitemap_simple_sitemap_insert(SimpleSitemap $entity) {
+  $sitemap_id =$entity->id();
+  if ($term_id = _tide_site_simple_sitemap_extract_site_number($sitemap_id)){
+    if(Term::load($term_id) && $entity->getType()->getOriginalId() === 'tide_default_sitemap_type'){
+      /** @var Drupal\simple_sitemap\Manager\Generator $custom_generator */
+      $custom_generator = \Drupal::service('simple_sitemap.generator');
+      $custom_generator->setSitemaps($entity->id());
+      $site_based_custom_link = $custom_generator->customLinkManager()->get('/');
+      if (isset($site_based_custom_link[$sitemap_id]) && empty($site_based_custom_link[$sitemap_id])){
+        $custom_generator->customLinkManager()->add(
+          '/',
+          ["path" => "/", "priority" => "1.0", "changefreq" => "daily"]
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Extract site number from the sitemap id.
+ */
+function _tide_site_simple_sitemap_extract_site_number($string) {
+  if (preg_match('/^site-(\d+)$/', $string, $matches)) {
+    return $matches[1];
+  }
+  return null;
 }


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-8510

### Issue
when creating a new sitemap, e.g. site-9203, via UI, the default url `/` doesn't create automatically. 

### Fix
fixed by implementing a `hook_ENTITY_TYPE_insert`